### PR TITLE
Fix error using incorrect method name: isAbsolutePath -> isAbsolute

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -54,7 +54,7 @@ function findServicePath() {
  * @param {Object} options - options.script may contain path to test script
  */
 function copyTestScript(options) {
-    const isAbsolutePath = path.isAbsolutePath(options.script),
+    const isAbsolutePath = path.isAbsolute(options.script),
           localScriptPath = path.join(process.cwd(), options.script),
           scriptFilename = path.basename(localScriptPath),
           projectServicePath = findServicePath();


### PR DESCRIPTION
Fixes broken run command.