### PR TITLE
Lint `bin/serverless-artillery` too

### DIFF
--- a/bin/serverless-artillery
+++ b/bin/serverless-artillery
@@ -2,96 +2,103 @@
 
 'use strict';
 
-const packageJson = require('../package.json'),
-    slsArt = require('../lib/'),
-    yargs = require('yargs')
-        .help()
-        .version(packageJson.version)
-        .options({
-            debug: {
-                alias: 'D',
-                description: 'Run the command in debug mode.',
-                requiresArg: false
-            },
-            verbose: {
-                alias: 'v',
-                description: 'Run the command in verbose mode.',
-                requiresArg: false
-            }
-        })
-        .global('debug')
-        .command('deploy', 'Deploy a default version of the function that will execute your Artillery scripts.', {
-            func: {
-                alias: 'f',
-                description: 'Lambda function name to execute.',
-                requiresArg: true,
-                type: 'string',
-                default: 'loadGenerator'
-            }
-        })
-        .command('run', 'Run your Artillery script.  Will prefer a script given by `-s` over a `script.[yml|json]` in the current directory over the default script.', {
-            script: {
-                alias: 's',
-                description: 'The Artillery script to execute.',
-                requiresArg: true,
-                type: 'string',
-                default: 'script.yml'
-            },
-            func: {
-                alias: 'f',
-                description: 'Lambda function name to execute.',
-                requiresArg: true,
-                type: 'string',
-                default: 'loadGenerator'
-            }
-        })
-        .command('cleanup', 'Remove the function and the associated resources created for or by it.', {
-            func: {
-                alias: 'f',
-                description: 'Lambda function name to execute.',
-                requiresArg: true,
-                type: 'string',
-                default: 'loadGenerator'
-            }
-        })
-        .command('script', 'Create a local Artillery script so that you can customize it for your specific load requirements.  See https://artillery.io for documentation.', {
-            endpoint: {
-                alias: 'e',
-                description: 'The endpoint to load with traffic.',
-                requiresArg: true,
-                type: 'string',
-                default: 'http://aws.amazon.com'
-            },
-            duration: {
-                alias: 'd',
-                description: 'The duration, in seconds, to load the given endpoint.',
-                requiresArg: true,
-                type: 'number',
-                default: 10
-            },
-            rate: {
-                alias: 'r',
-                description: 'The rate, in requests per second, at which to load the given endpoint.',
-                requiresArg: true,
-                type: 'number',
-                default: 2
-            },
-            rampTo: {
-                alias: 't',
-                description: 'The rate to adjust towards away from the given rate, in requests per second at which to load the given endpoint.',
-                requiresArg: true,
-                type: 'number'
-            }
-        })
-        .command('configure', 'Create a local copy of the deployment assets for modification and deployment.  See https://docs.serverless.com for documentation.', {})
-        .demand(1)
-        .strict()
-        .argv,
-    command = yargs._[0];
+const packageJson = require('../package.json');
+const slsArt = require('../lib/');
+const yargs = require('yargs')
+  .help()
+  .version(packageJson.version)
+  .options({
+    debug: {
+      alias: 'D',
+      description: 'Run the command in debug mode.',
+      requiresArg: false,
+    },
+    verbose: {
+      alias: 'v',
+      description: 'Run the command in verbose mode.',
+      requiresArg: false,
+    },
+  })
+  .global('debug')
+  .command('deploy', 'Deploy a default version of the function that will execute your Artillery scripts.', {
+    func: {
+      alias: 'f',
+      description: 'Lambda function name to execute.',
+      requiresArg: true,
+      type: 'string',
+      default: 'loadGenerator',
+    },
+  })
+  .command('run', 'Run your Artillery script.  Will prefer a script given by `-s` over a `script.[yml|json]` in ' +
+    'the current directory over the default script.',
+  {
+    script: {
+      alias: 's',
+      description: 'The Artillery script to execute.',
+      requiresArg: true,
+      type: 'string',
+      default: 'script.yml',
+    },
+    func: {
+      alias: 'f',
+      description: 'Lambda function name to execute.',
+      requiresArg: true,
+      type: 'string',
+      default: 'loadGenerator',
+    },
+  })
+  .command('cleanup', 'Remove the function and the associated resources created for or by it.', {
+    func: {
+      alias: 'f',
+      description: 'Lambda function name to execute.',
+      requiresArg: true,
+      type: 'string',
+      default: 'loadGenerator',
+    },
+  })
+  .command('script', 'Create a local Artillery script so that you can customize it for your specific load ' +
+    'requirements.  See https://artillery.io for documentation.',
+  {
+    endpoint: {
+      alias: 'e',
+      description: 'The endpoint to load with traffic.',
+      requiresArg: true,
+      type: 'string',
+      default: 'http://aws.amazon.com',
+    },
+    duration: {
+      alias: 'd',
+      description: 'The duration, in seconds, to load the given endpoint.',
+      requiresArg: true,
+      type: 'number',
+      default: 10,
+    },
+    rate: {
+      alias: 'r',
+      description: 'The rate, in requests per second, at which to load the given endpoint.',
+      requiresArg: true,
+      type: 'number',
+      default: 2,
+    },
+    rampTo: {
+      alias: 't',
+      description: 'The rate to adjust towards away from the given rate, in requests per second at which to load ' +
+        'the given endpoint.',
+      requiresArg: true,
+      type: 'number',
+    },
+  })
+  .command('configure', 'Create a local copy of the deployment assets for modification and deployment.  See ' +
+    'https://docs.serverless.com for documentation.', {})
+  .demand(1)
+  .strict()
+  .argv;
+
+const command = yargs._[0];
 
 if (yargs.debug) {
-    console.log(`options were:\n${JSON.stringify(yargs, null, 2)}`);
-    console.log(`command that will be run: slsArt[${command}](${yargs})`);
+  console.log(`options were:\n${JSON.stringify(yargs, null, 2)}`);
+  console.log(`command that will be run: slsArt[${command}](${yargs})`);
 }
 
 slsArt[command](yargs);

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "test": "mocha -r aws-sdk -r artillery-core --recursive -R min tests",
-    "lint": "eslint .",
+    "lint": "eslint . bin/serverless-artillery",
     "postinstall": "node ./postinstall.js"
   },
   "repository": {


### PR DESCRIPTION
1. Because it doesn't have the .js extension, `bin/serverless-artillery` was not being linted.  Add it to the lint targets.
2. Fix linting errors