### PR TITLE
Rename customize to configure

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -216,7 +216,7 @@ module.exports = {
   /**
    * Copy files necessary to allow user to customize the testing Lambda.
    */
-  customize: () => {
+  configure: () => {
     const lambdaFilesToCopy = [
       { source: 'serverless.yml' },
       { source: 'handler.js' },


### PR DESCRIPTION
We want to use "configure" not "customize"