### PR TITLE
Check Serverless Version

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ const BbPromise = require('bluebird');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const semver = require('semver');
 const shortid = require('shortid');
 const url = require('url');
 const yaml = require('yaml');
@@ -154,10 +155,19 @@ const impl = {
    * contain CLI parameters to pass to SLS.
    */
   serverlessRunner: (options) => {
+    const compatibleVersion = '^1.0.3';
     const serverless = new Serverless({
       interactive: false,
       servicePath: impl.findServicePath(),
     });
+    if (options.verbose) {
+      console.log(`Serverless version is ${serverless.version}, compatible version is '${compatibleVersion}'`);
+    }
+    if (!semver.satisfies(serverless.version, compatibleVersion)) {
+      return BbPromise.reject(new Error(
+        `Loaded Serverless version '${serverless.version}' but the compatible version is ${compatibleVersion}`
+      ));
+    }
     let SLS_DEBUG;
     if (options.debug) {
       console.log(`Running Serverless with argv: ${process.argv}`);

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "artillery-core": "^2.0.0-0",
     "aws-sdk": "^2.5.0",
     "bluebird": "^3.4.6",
+    "semver": "^5.3.0",
     "shortid": "^2.2.6",
     "yaml": "^0.3.0",
     "yargs": "^6.2.0"

--- a/tests/serverless-artillery.spec.js
+++ b/tests/serverless-artillery.spec.js
@@ -15,6 +15,7 @@ let serverlessMocks = [];
 
 class serverlessMock {
   constructor(config) {
+    this.version = config.version || '1.0.3';
     this.config = config;
     serverlessMocks.push(this);
   }


### PR DESCRIPTION
Fix #19
Include semver.
Use it to make sure the loaded version of SLS is compatible with `^1.0.3`
Update SLS mock in tests