### PR TITLE
Increase Hard-Coded Maximums

### DIFF
--- a/lib/lambda/handler.js
+++ b/lib/lambda/handler.js
@@ -15,26 +15,54 @@ const lambda = new aws.Lambda({ maxRetries: 0 });
 const constants = {
   CLOCK_DRIFT_THRESHOLD: 250,
   /**
+   * The hard coded maximum duration for an entire load test (as a set of jobs) in seconds.
+   * (_split.maxScriptDurationInSeconds must be set in your script if you want to use values up to this length)
+   */
+  MAX_SCRIPT_DURATION_IN_SECONDS: 518400, // 3 days
+  /**
    * The default maximum duration for an entire load test (as a set of jobs) in seconds
    */
-  MAX_SCRIPT_DURATION_IN_SECONDS: 86400,
+  DEFAULT_MAX_SCRIPT_DURATION_IN_SECONDS: 86400, // 12 hours
+  /**
+   * The default maximum number of concurrent lambdas to invoke with the given script.
+   * (_split.maxScriptRequestsPerSecond must be set in your script if you want to use values up to this rate)
+   */
+  MAX_SCRIPT_REQUESTS_PER_SECOND: 50000,
   /**
    * The default maximum number of concurrent lambdas to invoke with the given script
    */
-  MAX_SCRIPT_REQUESTS_PER_SECOND: 5000,
+  DEFAULT_MAX_SCRIPT_REQUESTS_PER_SECOND: 5000,
   /**
-   * The default maximum duration for a scenario in seconds
+   * The hard coded maximum duration for a single lambda to execute in seconds this should probably never change until
+   * Lambda maximums are increased.
+   * (_split.maxChunkDurationInSeconds must be set in your script if you want to use values up to this length)
    */
-  MAX_CHUNK_DURATION_IN_SECONDS: 240,
+  MAX_CHUNK_DURATION_IN_SECONDS: 285, // 4 minutes and 45 seconds (allow for 15 second alignment time)
+  /**
+   * The default maximum duration for a scenario in seconds (this is how much time a script is allowed to take before
+   * it will be split across multiple function executions)
+   */
+  DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS: 240, // 4 minutes
+  /**
+   * The hard coded maximum number of requests per second that a single lambda should attempt.  This is more than a
+   * fully powered Lambda can properly perform without impacting the measurements.
+   * (_split.maxChunkRequestsPerSecond must be set in your script if you want to use values up to this rate)
+   */
+  MAX_CHUNK_REQUESTS_PER_SECOND: 500,
   /**
    * The default maximum number of requests per second that a single lambda should attempt
    */
-  MAX_CHUNK_REQUESTS_PER_SECOND: 25,
+  DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND: 25,
+  /**
+   * The hard coded maximum number of seconds to wait for your functions to start producing load.
+   * (_split.timeBufferInMilliseconds must be set in your script if you want to use values up to this length)
+   */
+  MAX_TIME_BUFFER_IN_MILLISECONDS: 30000,
   /**
    * The default amount of buffer time to provide between starting a "next job" (to avoid cold starts and the
    * like) in milliseconds
    */
-  TIME_BUFFER_IN_MILLISECONDS: 15000,
+  DEFAULT_MAX_TIME_BUFFER_IN_MILLISECONDS: 15000,
 };
 const simulation = {
   callback: (err, res) => {
@@ -63,11 +91,11 @@ const impl = {
    */
   getSettings: (script) => {
     const ret = {
-      maxScriptDurationInSeconds: constants.MAX_SCRIPT_DURATION_IN_SECONDS,
-      maxScriptRequestsPerSecond: constants.MAX_SCRIPT_REQUESTS_PER_SECOND,
-      maxChunkDurationInSeconds: constants.MAX_CHUNK_DURATION_IN_SECONDS,
-      maxChunkRequestsPerSecond: constants.MAX_CHUNK_REQUESTS_PER_SECOND,
-      timeBufferInMilliseconds: constants.TIME_BUFFER_IN_MILLISECONDS,
+      maxScriptDurationInSeconds: constants.DEFAULT_MAX_SCRIPT_DURATION_IN_SECONDS,
+      maxScriptRequestsPerSecond: constants.DEFAULT_MAX_SCRIPT_REQUESTS_PER_SECOND,
+      maxChunkDurationInSeconds: constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS,
+      maxChunkRequestsPerSecond: constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND,
+      timeBufferInMilliseconds: constants.DEFAULT_MAX_TIME_BUFFER_IN_MILLISECONDS,
     };
     if (script._split) {
       if (script._split.maxScriptDurationInSeconds) {
@@ -207,14 +235,30 @@ const impl = {
       callback('If specified the "_split.maxScriptDuration" attribute must be an integer inclusively between ' +
       `1 and ${constants.MAX_SCRIPT_DURATION_IN_SECONDS}.`);
     } else if (
+      settings.maxChunkRequestsPerSecond &&
+      !(Number.isInteger(settings.maxChunkRequestsPerSecond) &&
+      settings.maxChunkRequestsPerSecond > 0 &&
+      settings.maxChunkRequestsPerSecond <= constants.MAX_CHUNK_REQUESTS_PER_SECOND)
+    ) {
+      callback('If specified the "_split.maxChunkRequestsPerSecond" attribute must be an integer inclusively ' +
+        `between 1 and ${constants.MAX_CHUNK_REQUESTS_PER_SECOND}.`);
+    } else if (
       settings.maxScriptRequestsPerSecond &&
       !(Number.isInteger(settings.maxScriptRequestsPerSecond) &&
       settings.maxScriptRequestsPerSecond > 0 &&
       settings.maxScriptRequestsPerSecond <= constants.MAX_SCRIPT_REQUESTS_PER_SECOND)
     ) {
       callback('If specified the "_split.maxScriptRequestsPerSecond" attribute must be an integer inclusively ' +
-      `between 1 and ${constants.MAX_SCRIPT_REQUESTS_PER_SECOND}.`);
-    // Validate the Phases
+        `between 1 and ${constants.MAX_SCRIPT_REQUESTS_PER_SECOND}.`);
+    } else if (
+      settings.timeBufferInMilliseconds &&
+      !(Number.isInteger(settings.timeBufferInMilliseconds) &&
+      settings.timeBufferInMilliseconds > 0 &&
+      settings.timeBufferInMilliseconds <= constants.MAX_TIME_BUFFER_IN_MILLISECONDS)
+    ) {
+      callback('If specified the "_split.timeBufferInMilliseconds" attribute must be an integer inclusively ' +
+        `between 1 and ${constants.MAX_TIME_BUFFER_IN_MILLISECONDS}.`);
+      // Validate the Phases
     } else if (!(script.config && Array.isArray(script.config.phases) && script.config.phases.length > 0)) {
       callback('An Artillery script must contain at least one phase under the $.config.phases attribute which ' +
         'itself must be an Array');
@@ -689,11 +733,11 @@ const impl = {
    * Customizable script splitting settings can be provided in an optional "_split" attribute, an example of which
    * follows:
    *  {
-   *      maxScriptDurationInSeconds: 86400,  // max value - see constants.MAX_SCRIPT_DURATION_IN_SECONDS
-   *      maxScriptRequestsPerSecond: 5000,   // max value - see constants.MAX_SCRIPT_REQUESTS_PER_SECOND
-   *      maxChunkDurationInSeconds: 240,     // max value - see constants.MAX_CHUNK_DURATION_IN_SECONDS
-   *      maxChunkRequestsPerSecond: 50,      // max value - see constants.MAX_CHUNK_REQUESTS_PER_SECOND
-   *      timeBufferInMilliseconds: 15000,    // default   - see constants.TIME_BUFFER_IN_MILLISECONDS
+   *      maxScriptDurationInSeconds: 86400,  // max value - see constants.DEFAULT_MAX_SCRIPT_DURATION_IN_SECONDS
+   *      maxScriptRequestsPerSecond: 5000,   // max value - see constants.DEFAULT_MAX_SCRIPT_REQUESTS_PER_SECOND
+   *      maxChunkDurationInSeconds: 240,     // max value - see constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS
+   *      maxChunkRequestsPerSecond: 25,      // max value - see constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND
+   *      timeBufferInMilliseconds: 15000,    // default   - see constants.DEFAULT_MAX_TIME_BUFFER_IN_MILLISECONDS
    *  }
    *
    * TODO What if there is not external reporting for a script that requires splitting?  Detect this and error out?

--- a/tests/handler.spec.js
+++ b/tests/handler.spec.js
@@ -15,95 +15,95 @@ describe('serverless-artillery Handler Tests', () => {
   describe('#splitPhaseByLength splits PHASES that are TOO LONG', () => {
     it('splitting a constant rate phase of three chunk\'s length into two parts.', () => {
       phase = {
-        duration: 3 * handler.constants.MAX_CHUNK_DURATION_IN_SECONDS,
+        duration: 3 * handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS,
         arrivalRate: 1,
       };
       expected = {
         chunk: {
-          duration: handler.constants.MAX_CHUNK_DURATION_IN_SECONDS,
+          duration: handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS,
           arrivalRate: 1,
         },
         remainder: {
-          duration: 2 * handler.constants.MAX_CHUNK_DURATION_IN_SECONDS,
+          duration: 2 * handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS,
           arrivalRate: 1,
         },
       };
-      result = handler.impl.splitPhaseByLength(phase, handler.constants.MAX_CHUNK_DURATION_IN_SECONDS);
+      result = handler.impl.splitPhaseByLength(phase, handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS);
       expect(result).to.deep.equal(expected);
     });
     it('splitting a ramping phase of two chunk\'s length into two parts.', () => {
       phase = {
-        duration: 3 * handler.constants.MAX_CHUNK_DURATION_IN_SECONDS,
+        duration: 3 * handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS,
         arrivalRate: 1,
         rampTo: 4,
       };
       expected = {
         chunk: {
-          duration: handler.constants.MAX_CHUNK_DURATION_IN_SECONDS,
+          duration: handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS,
           arrivalRate: 1,
           rampTo: 2,
         },
         remainder: {
-          duration: 2 * handler.constants.MAX_CHUNK_DURATION_IN_SECONDS,
+          duration: 2 * handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS,
           arrivalRate: 2,
           rampTo: 4,
         },
       };
-      result = handler.impl.splitPhaseByLength(phase, handler.constants.MAX_CHUNK_DURATION_IN_SECONDS);
+      result = handler.impl.splitPhaseByLength(phase, handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS);
       expect(result).to.deep.equal(expected);
     });
     it('splits ramp of two chunk\'s length into two parts, rounding to the nearest integer rate per second.', () => {
       phase = {
-        duration: 2 * handler.constants.MAX_CHUNK_DURATION_IN_SECONDS,
+        duration: 2 * handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS,
         arrivalRate: 1,
         rampTo: 2,
       };
       expected = {
         chunk: {
-          duration: handler.constants.MAX_CHUNK_DURATION_IN_SECONDS,
+          duration: handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS,
           arrivalRate: 1,
           rampTo: 2,
         },
         remainder: {
-          duration: handler.constants.MAX_CHUNK_DURATION_IN_SECONDS,
+          duration: handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS,
           arrivalRate: 2,
           rampTo: 2,
         },
       };
-      result = handler.impl.splitPhaseByLength(phase, handler.constants.MAX_CHUNK_DURATION_IN_SECONDS);
+      result = handler.impl.splitPhaseByLength(phase, handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS);
       expect(result).to.deep.equal(expected);
     });
     it('splitting an arrival count phase of two chunk\'s length into two parts.', () => {
       phase = {
-        duration: 2 * handler.constants.MAX_CHUNK_DURATION_IN_SECONDS,
-        arrivalCount: 2 * handler.constants.MAX_CHUNK_DURATION_IN_SECONDS,
+        duration: 2 * handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS,
+        arrivalCount: 2 * handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS,
       };
       expected = {
         chunk: {
-          duration: handler.constants.MAX_CHUNK_DURATION_IN_SECONDS,
-          arrivalCount: handler.constants.MAX_CHUNK_DURATION_IN_SECONDS,
+          duration: handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS,
+          arrivalCount: handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS,
         },
         remainder: {
-          duration: handler.constants.MAX_CHUNK_DURATION_IN_SECONDS,
-          arrivalCount: handler.constants.MAX_CHUNK_DURATION_IN_SECONDS,
+          duration: handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS,
+          arrivalCount: handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS,
         },
       };
-      result = handler.impl.splitPhaseByLength(phase, handler.constants.MAX_CHUNK_DURATION_IN_SECONDS);
+      result = handler.impl.splitPhaseByLength(phase, handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS);
       expect(result).to.deep.equal(expected);
     });
     it('splitting a pause phase of two chunk\'s length into two parts.', () => {
       phase = {
-        pause: 2 * handler.constants.MAX_CHUNK_DURATION_IN_SECONDS,
+        pause: 2 * handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS,
       };
       expected = {
         chunk: {
-          pause: handler.constants.MAX_CHUNK_DURATION_IN_SECONDS,
+          pause: handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS,
         },
         remainder: {
-          pause: handler.constants.MAX_CHUNK_DURATION_IN_SECONDS,
+          pause: handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS,
         },
       };
-      result = handler.impl.splitPhaseByLength(phase, handler.constants.MAX_CHUNK_DURATION_IN_SECONDS);
+      result = handler.impl.splitPhaseByLength(phase, handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS);
       expect(result).to.deep.equal(expected);
     });
   });
@@ -116,11 +116,11 @@ describe('serverless-artillery Handler Tests', () => {
         config: {
           phases: [
             {
-              duration: handler.constants.MAX_CHUNK_DURATION_IN_SECONDS,
+              duration: handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS,
               arrivalRate: 1,
             },
             {
-              duration: handler.constants.MAX_CHUNK_DURATION_IN_SECONDS,
+              duration: handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS,
               arrivalRate: 2,
             },
           ],
@@ -131,7 +131,7 @@ describe('serverless-artillery Handler Tests', () => {
           config: {
             phases: [
               {
-                duration: handler.constants.MAX_CHUNK_DURATION_IN_SECONDS,
+                duration: handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS,
                 arrivalRate: 1,
               },
             ],
@@ -141,14 +141,14 @@ describe('serverless-artillery Handler Tests', () => {
           config: {
             phases: [
               {
-                duration: handler.constants.MAX_CHUNK_DURATION_IN_SECONDS,
+                duration: handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS,
                 arrivalRate: 2,
               },
             ],
           },
         },
       };
-      result = handler.impl.splitScriptByLength(script, handler.constants.MAX_CHUNK_DURATION_IN_SECONDS);
+      result = handler.impl.splitScriptByLength(script, handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS);
       expect(result).to.deep.equal(expected);
     });
     it('splitting a script where there is a natural phase split at MAX_CHUNK_DURATION between many phases.', () => {
@@ -156,23 +156,23 @@ describe('serverless-artillery Handler Tests', () => {
         config: {
           phases: [
             {
-              duration: Math.floor(handler.constants.MAX_CHUNK_DURATION_IN_SECONDS * 0.5),
+              duration: Math.floor(handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS * 0.5),
               arrivalRate: 1,
             },
             {
-              duration: Math.ceil(handler.constants.MAX_CHUNK_DURATION_IN_SECONDS * 0.5),
+              duration: Math.ceil(handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS * 0.5),
               arrivalRate: 1,
             },
             {
-              duration: Math.floor(handler.constants.MAX_CHUNK_DURATION_IN_SECONDS * 0.5),
+              duration: Math.floor(handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS * 0.5),
               arrivalRate: 1,
             },
             {
-              duration: Math.ceil(handler.constants.MAX_CHUNK_DURATION_IN_SECONDS * 0.5),
+              duration: Math.ceil(handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS * 0.5),
               arrivalRate: 1,
             },
             {
-              duration: handler.constants.MAX_CHUNK_DURATION_IN_SECONDS,
+              duration: handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS,
               arrivalRate: 2,
             },
           ],
@@ -183,11 +183,11 @@ describe('serverless-artillery Handler Tests', () => {
           config: {
             phases: [
               {
-                duration: Math.floor(handler.constants.MAX_CHUNK_DURATION_IN_SECONDS * 0.5),
+                duration: Math.floor(handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS * 0.5),
                 arrivalRate: 1,
               },
               {
-                duration: Math.ceil(handler.constants.MAX_CHUNK_DURATION_IN_SECONDS * 0.5),
+                duration: Math.ceil(handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS * 0.5),
                 arrivalRate: 1,
               },
             ],
@@ -197,22 +197,22 @@ describe('serverless-artillery Handler Tests', () => {
           config: {
             phases: [
               {
-                duration: Math.floor(handler.constants.MAX_CHUNK_DURATION_IN_SECONDS * 0.5),
+                duration: Math.floor(handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS * 0.5),
                 arrivalRate: 1,
               },
               {
-                duration: Math.ceil(handler.constants.MAX_CHUNK_DURATION_IN_SECONDS * 0.5),
+                duration: Math.ceil(handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS * 0.5),
                 arrivalRate: 1,
               },
               {
-                duration: handler.constants.MAX_CHUNK_DURATION_IN_SECONDS,
+                duration: handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS,
                 arrivalRate: 2,
               },
             ],
           },
         },
       };
-      result = handler.impl.splitScriptByLength(script, handler.constants.MAX_CHUNK_DURATION_IN_SECONDS);
+      result = handler.impl.splitScriptByLength(script, handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS);
       expect(result).to.deep.equal(expected);
     });
     it('splitting a script where a phase must be split at MAX_CHUNK_DURATION.', () => {
@@ -220,15 +220,15 @@ describe('serverless-artillery Handler Tests', () => {
         config: {
           phases: [
             {
-              duration: Math.floor(handler.constants.MAX_CHUNK_DURATION_IN_SECONDS * 0.75),
+              duration: Math.floor(handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS * 0.75),
               arrivalRate: 1,
             },
             {
-              duration: Math.ceil(handler.constants.MAX_CHUNK_DURATION_IN_SECONDS * 0.75),
+              duration: Math.ceil(handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS * 0.75),
               arrivalRate: 1,
             },
             {
-              duration: Math.floor(handler.constants.MAX_CHUNK_DURATION_IN_SECONDS * 0.75),
+              duration: Math.floor(handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS * 0.75),
               arrivalRate: 1,
             },
           ],
@@ -239,11 +239,11 @@ describe('serverless-artillery Handler Tests', () => {
           config: {
             phases: [
               {
-                duration: Math.floor(handler.constants.MAX_CHUNK_DURATION_IN_SECONDS * 0.75),
+                duration: Math.floor(handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS * 0.75),
                 arrivalRate: 1,
               },
               {
-                duration: Math.ceil(handler.constants.MAX_CHUNK_DURATION_IN_SECONDS * 0.25),
+                duration: Math.ceil(handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS * 0.25),
                 arrivalRate: 1,
               },
             ],
@@ -253,18 +253,18 @@ describe('serverless-artillery Handler Tests', () => {
           config: {
             phases: [
               {
-                duration: Math.floor(handler.constants.MAX_CHUNK_DURATION_IN_SECONDS * 0.5),
+                duration: Math.floor(handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS * 0.5),
                 arrivalRate: 1,
               },
               {
-                duration: Math.ceil(handler.constants.MAX_CHUNK_DURATION_IN_SECONDS * 0.75),
+                duration: Math.ceil(handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS * 0.75),
                 arrivalRate: 1,
               },
             ],
           },
         },
       };
-      result = handler.impl.splitScriptByLength(script, handler.constants.MAX_CHUNK_DURATION_IN_SECONDS);
+      result = handler.impl.splitScriptByLength(script, handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS);
       expect(result).to.deep.equal(expected);
     });
   });
@@ -273,44 +273,44 @@ describe('serverless-artillery Handler Tests', () => {
    */
   describe('#splitPhaseByWidth The handler splits PHASES that are TOO WIDE (RPS > MAX_RPS)', () => {
     // min >= chunkSize
-    it('splitting a ramp phase that at all times exceeds a rate of MAX_CHUNK_REQUESTS_PER_SECOND into a constant' +
-      ' rate and remainder ramp phases.', () => {
+    it('splitting a ramp phase that at all times exceeds a rate of DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND into a' +
+      ' constant rate and remainder ramp phases.', () => {
       phase = {
-        arrivalRate: handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND * 2,
-        rampTo: handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND * 3,
+        arrivalRate: handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND * 2,
+        rampTo: handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND * 3,
         duration: 1,
       };
       expected = {
         chunk: [
           {
-            arrivalRate: handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND,
+            arrivalRate: handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND,
             duration: 1,
           },
         ],
         remainder: [
           {
-            arrivalRate: handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND,
-            rampTo: handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND * 2,
+            arrivalRate: handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND,
+            rampTo: handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND * 2,
             duration: 1,
           },
         ],
       };
-      result = handler.impl.splitPhaseByWidth(phase, handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND);
+      result = handler.impl.splitPhaseByWidth(phase, handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND);
       expect(result).to.deep.equal(expected);
     });
     // max <= chunkSize
-    it('splitting ramp that at all times is less than MAX_CHUNK_REQUESTS_PER_SECOND into a chunk of the ramp phase ' +
-      'and a remainder of a pause phase.', () => {
+    it('splitting ramp that at all times is less than DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND into a chunk of the ramp' +
+      ' phase and a remainder of a pause phase.', () => {
       phase = {
-        arrivalRate: Math.floor(handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND * 0.5),
-        rampTo: Math.floor(handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND * 0.75),
+        arrivalRate: Math.floor(handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND * 0.5),
+        rampTo: Math.floor(handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND * 0.75),
         duration: 1,
       };
       expected = {
         chunk: [
           {
-            arrivalRate: Math.floor(handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND * 0.5),
-            rampTo: Math.floor(handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND * 0.75),
+            arrivalRate: Math.floor(handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND * 0.5),
+            rampTo: Math.floor(handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND * 0.75),
             duration: 1,
           },
         ],
@@ -320,26 +320,26 @@ describe('serverless-artillery Handler Tests', () => {
           },
         ],
       };
-      result = handler.impl.splitPhaseByWidth(phase, handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND);
+      result = handler.impl.splitPhaseByWidth(phase, handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND);
       expect(result).to.deep.equal(expected);
     });
-    it('splitting an ascending ramp phase that starts lower than and ends higher than MAX_CHUNK_REQUESTS_PER_SECOND ' +
-      'into a chunk of a ramp phase followed by a constant rate phase and a remainder of a pause phase followed by a ' +
-      'ramp phase.', () => {
+    it('splitting an ascending ramp phase that starts lower than and ends higher than' +
+      ' DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND into a chunk of a ramp phase followed by a constant rate phase and a' +
+      ' remainder of a pause phase followed by a ramp phase.', () => {
       phase = {
-        arrivalRate: handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND * 0.5,
-        rampTo: handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND * 1.5,
+        arrivalRate: handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND * 0.5,
+        rampTo: handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND * 1.5,
         duration: 2,
       };
       expected = {
         chunk: [
           {
             arrivalRate: phase.arrivalRate,
-            rampTo: handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND,
+            rampTo: handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND,
             duration: 1,
           },
           {
-            arrivalRate: handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND,
+            arrivalRate: handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND,
             duration: 1,
           },
         ],
@@ -349,37 +349,37 @@ describe('serverless-artillery Handler Tests', () => {
           },
           {
             arrivalRate: 1,
-            rampTo: (handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND * 1.5) - handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND, // eslint-disable-line max-len
+            rampTo: (handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND * 1.5) - handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND, // eslint-disable-line max-len
             duration: 1,
           },
         ],
       };
-      result = handler.impl.splitPhaseByWidth(phase, handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND);
+      result = handler.impl.splitPhaseByWidth(phase, handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND);
       expect(result).to.deep.equal(expected);
     });
-    it('splitting a descending ramp phase that starts lower than and ends higher than MAX_CHUNK_REQUESTS_PER_SECOND ' +
-      'into a chunk of a constant rate phase followed by a ramp phase and a remainder of a ramp phase followed by a ' +
-      'pause phase.', () => {
+    it('splitting a descending ramp phase that starts lower than and ends higher than' +
+      ' DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND into a chunk of a constant rate phase followed by a ramp phase and a' +
+      ' remainder of a ramp phase followed by a pause phase.', () => {
       phase = {
-        arrivalRate: handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND * 1.5,
-        rampTo: handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND * 0.5,
+        arrivalRate: handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND * 1.5,
+        rampTo: handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND * 0.5,
         duration: 2,
       };
       expected = {
         chunk: [
           {
-            arrivalRate: handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND,
+            arrivalRate: handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND,
             duration: 1,
           },
           {
-            arrivalRate: handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND,
+            arrivalRate: handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND,
             rampTo: phase.rampTo,
             duration: 1,
           },
         ],
         remainder: [
           {
-            arrivalRate: phase.arrivalRate - handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND,
+            arrivalRate: phase.arrivalRate - handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND,
             rampTo: 1,
             duration: 1,
           },
@@ -388,12 +388,12 @@ describe('serverless-artillery Handler Tests', () => {
           },
         ],
       };
-      result = handler.impl.splitPhaseByWidth(phase, handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND);
+      result = handler.impl.splitPhaseByWidth(phase, handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND);
       expect(result).to.deep.equal(expected);
     });
     it('splits an arrivalRate of less than a chunk\'s width into a chunk of that width and remainder of pause', () => {
       phase = {
-        arrivalRate: handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND * 0.75,
+        arrivalRate: handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND * 0.75,
         duration: 1,
       };
       expected = {
@@ -409,56 +409,56 @@ describe('serverless-artillery Handler Tests', () => {
           },
         ],
       };
-      result = handler.impl.splitPhaseByWidth(phase, handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND);
+      result = handler.impl.splitPhaseByWidth(phase, handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND);
       expect(result).to.deep.equal(expected);
     });
     it('splitting an arrivalRate phase of two chunk\'s width into two parts.', () => {
       phase = {
-        arrivalRate: handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND * 2,
+        arrivalRate: handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND * 2,
         duration: 1,
       };
       expected = {
         chunk: [
           {
-            arrivalRate: handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND,
+            arrivalRate: handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND,
             duration: 1,
           },
         ],
         remainder: [
           {
-            arrivalRate: handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND,
+            arrivalRate: handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND,
             duration: 1,
           },
         ],
       };
-      result = handler.impl.splitPhaseByWidth(phase, handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND);
+      result = handler.impl.splitPhaseByWidth(phase, handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND);
       expect(result).to.deep.equal(expected);
     });
     it('splitting an arrivalCount phase of two chunk\'s width into two parts.', () => {
       phase = {
-        arrivalCount: handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND * 2,
+        arrivalCount: handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND * 2,
         duration: 1,
       };
       expected = {
         chunk: [
           {
-            arrivalCount: handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND,
+            arrivalCount: handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND,
             duration: 1,
           },
         ],
         remainder: [
           {
-            arrivalCount: handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND,
+            arrivalCount: handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND,
             duration: 1,
           },
         ],
       };
-      result = handler.impl.splitPhaseByWidth(phase, handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND);
+      result = handler.impl.splitPhaseByWidth(phase, handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND);
       expect(result).to.deep.equal(expected);
     });
     it('splitting an arrivalCount phase of less than chunkSize\'s width into an arrival count and pause phase.', () => {
       phase = {
-        arrivalCount: handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND * 0.75,
+        arrivalCount: handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND * 0.75,
         duration: 1,
       };
       expected = {
@@ -474,22 +474,22 @@ describe('serverless-artillery Handler Tests', () => {
           },
         ],
       };
-      result = handler.impl.splitPhaseByWidth(phase, handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND);
+      result = handler.impl.splitPhaseByWidth(phase, handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND);
       expect(result).to.deep.equal(expected);
     });
     it('splitting a pause phase into two pause phases.', () => {
       phase = {
-        pause: handler.constants.MAX_CHUNK_DURATION_IN_SECONDS,
+        pause: handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS,
       };
       expected = {
         chunk: [
-          { pause: handler.constants.MAX_CHUNK_DURATION_IN_SECONDS },
+          { pause: handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS },
         ],
         remainder: [
-          { pause: handler.constants.MAX_CHUNK_DURATION_IN_SECONDS },
+          { pause: handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS },
         ],
       };
-      result = handler.impl.splitPhaseByWidth(phase, handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND);
+      result = handler.impl.splitPhaseByWidth(phase, handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND);
       expect(result).to.deep.equal(expected);
     });
   });
@@ -497,13 +497,13 @@ describe('serverless-artillery Handler Tests', () => {
    * SPLIT SCRIPT BY WIDTH
    */
   describe('#splitScriptByWidth the handler splits SCRIPTS that are TOO WIDE', () => {
-    it('splits a script with a phase that specifies twice MAX_CHUNK_REQUESTS_PER_SECOND load.', () => {
+    it('splits a script with a phase that specifies twice DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND load.', () => {
       script = {
         config: {
           phases: [
             {
               duration: 1,
-              arrivalRate: handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND * 2,
+              arrivalRate: handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND * 2,
             },
           ],
         },
@@ -514,7 +514,7 @@ describe('serverless-artillery Handler Tests', () => {
             phases: [
               {
                 duration: 1,
-                arrivalRate: handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND,
+                arrivalRate: handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND,
               },
             ],
           },
@@ -524,26 +524,26 @@ describe('serverless-artillery Handler Tests', () => {
             phases: [
               {
                 duration: 1,
-                arrivalRate: handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND,
+                arrivalRate: handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND,
               },
             ],
           },
         },
       };
-      result = handler.impl.splitScriptByWidth(script, handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND);
+      result = handler.impl.splitScriptByWidth(script, handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND);
       expect(result).to.deep.equal(expected);
     });
-    it('splits a script of two phases that specify twice MAX_CHUNK_REQUESTS_PER_SECOND load to split.', () => {
+    it('splits a script of two phases that specify twice DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND load to split.', () => {
       script = {
         config: {
           phases: [
             {
               duration: 1,
-              arrivalRate: handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND * 2,
+              arrivalRate: handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND * 2,
             },
             {
               duration: 1,
-              arrivalRate: handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND * 2,
+              arrivalRate: handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND * 2,
             },
           ],
         },
@@ -554,11 +554,11 @@ describe('serverless-artillery Handler Tests', () => {
             phases: [
               {
                 duration: 1,
-                arrivalRate: handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND,
+                arrivalRate: handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND,
               },
               {
                 duration: 1,
-                arrivalRate: handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND,
+                arrivalRate: handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND,
               },
             ],
           },
@@ -568,17 +568,17 @@ describe('serverless-artillery Handler Tests', () => {
             phases: [
               {
                 duration: 1,
-                arrivalRate: handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND,
+                arrivalRate: handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND,
               },
               {
                 duration: 1,
-                arrivalRate: handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND,
+                arrivalRate: handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND,
               },
             ],
           },
         },
       };
-      result = handler.impl.splitScriptByWidth(script, handler.constants.MAX_CHUNK_REQUESTS_PER_SECOND);
+      result = handler.impl.splitScriptByWidth(script, handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND);
       expect(result).to.deep.equal(expected);
     });
   });


### PR DESCRIPTION
A number of parameters are used to determine when to split a script so that the entirety of the script can be executed on a single function.  This is helpful.  However, if you want to adjust them up, it is confining and requiring changing the code is largely a bit high of a bar.  Therefore, make the default values (max for single lambda) sensible (existing values) but make the hard coded maximum higher.  Do likewise for the script constraints.

Fix a few bugs:
   1. Missing validation for `maxChunkRequestsPerSecond`
   2. Missing validation for `timeBufferInMilliseconds`
   3. an incorrect comment.

Update tests appropriately.