### PR TITLE
Removed -d flag from 'invoke'

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -134,7 +134,7 @@ config:
     -
       duration: ${duration}
       arrivalRate: ${rate}`,
-    rampTo ? `
+      rampTo ? `
       rampTo: ${rampTo}` : // note that this is a break in the template string (to avoid spurious newline)
       '', `
 scenarios:
@@ -231,7 +231,7 @@ module.exports = {
       return BbPromise.reject(new Error(`${os.EOL}\tScript '${options.script}' could not be found.${os.EOL}`));
     }
     // start with default SLS command
-    process.argv = [null, null, 'invoke', '-d', '-f', constants.TestFunctionName, '-p', scriptPath];
+    process.argv = [null, null, 'invoke', '-f', constants.TestFunctionName, '-p', scriptPath];
     // load and analyze script
     const scriptData = impl.readScript(scriptPath);
     const scriptExtent = impl.scriptExtent(scriptData);

--- a/tests/serverless-artillery.spec.js
+++ b/tests/serverless-artillery.spec.js
@@ -74,7 +74,7 @@ describe('serverless-artillery command line interactions', () => {
       .then(() => {
         expect(serverlessMocks.length).to.equal(1);
         expect(serverlessMocks[0].initCalled).to.be.true;
-        expect(serverlessMocks[0].argv).to.eql([null, null, 'invoke', '-d', '-f', functionName, '-p', newScriptPath]);
+        expect(serverlessMocks[0].argv).to.eql([null, null, 'invoke', '-f', functionName, '-p', newScriptPath]);
         done();
       });
     });


### PR DESCRIPTION
The -d flag seems to be interpreted by SLS as the payload and not "deployed function" anymore.