### PR TITLE
Add region option to deploy/remove/invoke commands

### DIFF
--- a/bin/serverless-artillery
+++ b/bin/serverless-artillery
@@ -20,7 +20,14 @@ const yargs = require('yargs')
     },
   })
   .global('D', 'V')
-  .command('deploy', 'Deploy a default version of the function that will execute your Artillery scripts.', {})
+  .command('deploy', 'Deploy a default version of the function that will execute your Artillery scripts.', {
+    r: {
+      alias: 'region',
+      description: 'The region where the function will be deployed',
+      requiresArg: true,
+      type: 'string',
+    },
+  })
   .command('invoke', 'Invoke your function with your Artillery script.  Will prefer a script given by `-s` over a ' +
     '`script.[yml|json]` in the current directory over the preexisting default script.',
   {
@@ -30,8 +37,21 @@ const yargs = require('yargs')
       requiresArg: true,
       type: 'string',
     },
+    r: {
+      alias: 'region',
+      description: 'The region in which the function will be executed',
+      requiresArg: true,
+      type: 'string',
+    },
   })
-  .command('remove', 'Remove the function and the associated resources created for or by it.', {})
+  .command('remove', 'Remove the function and the associated resources created for or by it.', {
+    r: {
+      alias: 'region',
+      description: 'The region from which the function will be removed',
+      requiresArg: true,
+      type: 'string',
+    },
+  })
   .command('script', 'Create a local Artillery script so that you can customize it for your specific load ' +
     'requirements.  See https://artillery.io for documentation.',
   {

--- a/lib/index.js
+++ b/lib/index.js
@@ -129,7 +129,7 @@ const impl = {
 # https://artillery.io/docs/
 config:
   # this hostname will be used as a prefix for each URI in the flow unless a complete URI is specified
-  target: "${urlParts.protocol}//${urlParts.auth ? `${urlParts.auth}@` : ''}${urlParts.host}" 
+  target: "${urlParts.protocol}//${urlParts.auth ? `${urlParts.auth}@` : ''}${urlParts.host}"
   phases:
     -
       duration: ${duration}
@@ -211,6 +211,11 @@ module.exports = {
       process.argv.push('--verbose');
     }
 
+    if (options.region) {
+      process.argv.push('-r');
+      process.argv.push(options.region);
+    }
+
     console.log(`${os.EOL}\tDeploying Lambda to AWS...${os.EOL}`);
 
     return impl.serverlessRunner(options).then(() => {
@@ -232,6 +237,10 @@ module.exports = {
     }
     // start with default SLS command
     process.argv = [null, null, 'invoke', '-f', constants.TestFunctionName, '-p', scriptPath];
+    if (options.region) {
+      process.argv.push('-r');
+      process.argv.push(options.region);
+    }
     // load and analyze script
     const scriptData = impl.readScript(scriptPath);
     const scriptExtent = impl.scriptExtent(scriptData);
@@ -257,6 +266,11 @@ module.exports = {
     process.argv = [null, null, 'remove', '-f', constants.TestFunctionName];
     if (options.verbose) {
       process.argv.push('--verbose');
+    }
+
+    if (options.region) {
+      process.argv.push('-r');
+      process.argv.push(options.region);
     }
 
     console.log(`${os.EOL}\tRemoving Lambda from AWS...${os.EOL}`);


### PR DESCRIPTION
It's quite useful to be able to run tests from multiple regions using the same serverless.yml file. Serverless actually supports this via the -r cmd line parameter. I made a very small enhancement to serverless-artillery to support the same option on the command line and pass it through to serverless. Works great and allows me to launch tests from multiple regions easily.