### PR TITLE
Add support for artillery processor configuration

### DIFF
--- a/lib/lambda/handler.js
+++ b/lib/lambda/handler.js
@@ -692,6 +692,7 @@ const impl = {
       console.log(`SIMULATION: runLoad called with ${JSON.stringify(script, null, 2)}`);
     } else {
       try {
+        impl.loadProcessor(script);
         payload = impl.readPayload(script);
         runner = artillery.runner(script, payload, {});
         runner.on('phaseStarted', (opts) => {
@@ -724,6 +725,17 @@ const impl = {
         console.log(msg);
         callback(msg);
       }
+    }
+  },
+  /**
+   * Loads custom processor functions from artillery configuration
+   * @param script The Artillery (http://artillery.io) script to be executed
+   */
+  loadProcessor: (script) => {
+    const config = script.config;
+    if (config.processor) {
+      const processorPath = path.resolve(process.cwd(), config.processor);
+      config.processor = require(processorPath);
     }
   },
   /**

--- a/lib/lambda/handler.js
+++ b/lib/lambda/handler.js
@@ -735,7 +735,7 @@ const impl = {
     const config = script.config;
     if (config.processor) {
       const processorPath = path.resolve(process.cwd(), config.processor);
-      config.processor = require(processorPath);
+      config.processor = require(processorPath); // eslint-disable-line global-require,import/no-dynamic-require
     }
   },
   /**

--- a/lib/lambda/handler.js
+++ b/lib/lambda/handler.js
@@ -733,7 +733,7 @@ const impl = {
    */
   loadProcessor: (script) => {
     const config = script.config;
-    if (config.processor) {
+    if (config.processor && typeof config.processor === 'string') {
       const processorPath = path.resolve(process.cwd(), config.processor);
       config.processor = require(processorPath); // eslint-disable-line global-require,import/no-dynamic-require
     }

--- a/tests/customprocessor.js
+++ b/tests/customprocessor.js
@@ -1,0 +1,9 @@
+'use strict';
+
+function testMethod() {
+  return 'testValue';
+}
+
+module.exports = {
+  testMethod,
+};

--- a/tests/handler.spec.js
+++ b/tests/handler.spec.js
@@ -590,8 +590,18 @@ describe('serverless-artillery Handler Tests', () => {
         },
       };
       handler.impl.loadProcessor(newScript);
-      expect(newScript.config.processor).to.have.property('testMethod');
       expect(newScript.config.processor.testMethod()).to.equal('testValue');
+    });
+    it('does not attempt to reload a previously loaded processor', () => {
+      const newScript = {
+        config: {
+          processor: {
+            f: () => 'testValue',
+          },
+        },
+      };
+      handler.impl.loadProcessor(newScript);
+      expect(newScript.config.processor.f()).to.equal('testValue');
     });
   });
   describe('#readPayload', () => {

--- a/tests/handler.spec.js
+++ b/tests/handler.spec.js
@@ -582,6 +582,18 @@ describe('serverless-artillery Handler Tests', () => {
       expect(result).to.deep.equal(expected);
     });
   });
+  describe('#loadProcessor', () => {
+    it('loads custom processor code based on script configuration', () => {
+      const newScript = {
+        config: {
+          processor: `${__dirname}/customprocessor.js`,
+        },
+      };
+      handler.impl.loadProcessor(newScript);
+      expect(newScript.config.processor).to.have.property('testMethod');
+      expect(newScript.config.processor.testMethod()).to.equal('testValue');
+    });
+  });
   describe('#readPayload', () => {
     it('reads a single payload file.', () => {
       const newScript = {


### PR DESCRIPTION
Artillery has the concept of [processor](https://artillery.io/docs/testing_http.html#advanced-writing-custom-logic-in-javascript) for adding custom logic before/after query executions. I noticed this doesn't work in serverless-artillery. Digging a bit further it seems that artillery converts the processor value in the script into functions outside of the artillery-core project. I'm not sure why they do that, but the relevant few lines are of code can be found [here](https://github.com/shoreditch-ops/artillery/blob/master/lib/worker.js#L66). In order to get this feature to work in serverless-artillery, the equivalent procedure has to happen in the handler.js lambda. So I extended it to do just that and now I can have custom Javascript in my tests which is great!
One small issue is that the pre-commit script does not allow dynamic require so current code fails pre-commit. If you want to support this feature you will have to relax that.

[edit: direct link to the line of code]