### PR TITLE
Fix Length is Duration, Parse Failure, and Limit Check Bugs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -123,15 +123,15 @@ const impl = {
   /**
    * Get the extent and limits of the given script
    * @param script The script to determine extent for
-   * @return {{length: (*|number), width: (*|number), maxLength: *, maxWidth: *}}
+   * @return {{durationInSeconds: (*|number), requestsPerSecond: (*|number), maxDurationInSeconds:(*|number), maxRequestsPerSecond: (*|number)}}
    */
   scriptExtent(script) {
     const settings = handler.impl.getSettings(script)
     const ret = {
-      length: handler.impl.scriptLength(script),
-      width: handler.impl.scriptWidth(script),
-      maxLength: settings.maxScriptDurationInSeconds,
-      maxWidth: settings.maxChunkRequestsPerSecond,
+      durationInSeconds: handler.impl.scriptDurationInSeconds(script),
+      requestsPerSecond: handler.impl.scriptRequestsPerSecond(script),
+      maxDurationInSeconds: settings.maxScriptDurationInSeconds,
+      maxRequestsPerSecond: settings.maxChunkRequestsPerSecond,
     }
     let httpTimeout = 119 // slightly less than default 2 minutes
     if (
@@ -141,8 +141,8 @@ const impl = {
     ) {
       httpTimeout = Math.floor(aws.config.httpOptions.timeout / 1000) - 1 // convert from ms to s and reduce by 1
     }
-    if (ret.maxWidth > httpTimeout) { // reset to avoid HTTP timeout rather than Lambda timeout
-      ret.maxWidth = httpTimeout
+    if (ret.maxRequestsPerSecond > httpTimeout) { // reset to avoid HTTP timeout rather than Lambda timeout
+      ret.maxRequestsPerSecond = httpTimeout
     }
     return ret
   },
@@ -305,13 +305,13 @@ module.exports = {
       ) {
         const scriptExtent = impl.scriptExtent(script)
         const exceedsLimits =
-          scriptExtent.width > scriptExtent.maxWidth ||
-          scriptExtent.length > scriptExtent.maxLength
+          scriptExtent.requestsPerSecond > scriptExtent.maxRequestsPerSecond ||
+          scriptExtent.durationInSeconds > scriptExtent.maxDurationInSeconds
         if (exceedsLimits) { // exceeds limits?
           process.argv.push('-t')
           process.argv.push('Event')
           completeMessage = `${os.EOL}\tYour function has been invoked. The load is scheduled to be completed in ${
-            scriptExtent.length} seconds.${os.EOL}`
+            scriptExtent.durationInSeconds} seconds.${os.EOL}`
         }
       }
       // run the given script on the deployed lambda

--- a/lib/index.js
+++ b/lib/index.js
@@ -130,8 +130,8 @@ const impl = {
     const ret = {
       length: handler.impl.scriptLength(script),
       width: handler.impl.scriptWidth(script),
-      maxLength: settings.maxChunkRequestsPerSecond,
-      maxWidth: settings.maxScriptDurationInSeconds,
+      maxLength: settings.maxScriptDurationInSeconds,
+      maxWidth: settings.maxChunkRequestsPerSecond,
     }
     let httpTimeout = 119 // slightly less than default 2 minutes
     if (
@@ -238,8 +238,18 @@ scenarios:
         )
         const log = invoke.log
         invoke.log = (response) => {
-          if (response && 'Payload' in response && typeof response.Payload === 'string') {
-            result = JSON.parse(response.Payload)
+          if (response && 'Payload' in response && typeof response.Payload === 'string' && response.Payload.length) {
+            try {
+              result = JSON.parse(response.Payload)
+            } catch (ex) {
+              console.log(`exception parsing payload:${os.EOL
+              }${JSON.stringify(response)}${os.EOL
+              }${ex}${os.EOL}${os.EOL
+              }Please report this error to this tool's GitHub repo so that we can dig into the cause:${os.EOL
+              }https://github.com/Nordstrom/serverless-artillery/issues${os.EOL
+              }Please scrub any sensitive information that may be present prior to submission.${os.EOL
+              }Thank you!`)
+            }
           }
           return log.call(invoke, response)
         }
@@ -295,8 +305,8 @@ module.exports = {
       ) {
         const scriptExtent = impl.scriptExtent(script)
         const exceedsLimits =
-          scriptExtent.width >= scriptExtent.maxWidth ||
-          scriptExtent.length >= scriptExtent.maxLength
+          scriptExtent.width > scriptExtent.maxWidth ||
+          scriptExtent.length > scriptExtent.maxLength
         if (exceedsLimits) { // exceeds limits?
           process.argv.push('-t')
           process.argv.push('Event')

--- a/lib/lambda/handler.js
+++ b/lib/lambda/handler.js
@@ -14,7 +14,7 @@ const constants = {
   CLOCK_DRIFT_THRESHOLD: 250,
   /**
    * The hard coded maximum duration for an entire load test (as a set of jobs) in seconds.
-   * (_split.maxScriptDurationInSeconds must be set in your script if you want to use values up to this length)
+   * (_split.maxScriptDurationInSeconds must be set in your script if you want to use values up to this duration)
    */
   MAX_SCRIPT_DURATION_IN_SECONDS: 518400, // 6 days
   /**
@@ -33,7 +33,7 @@ const constants = {
   /**
    * The hard coded maximum duration for a single lambda to execute in seconds this should probably never change until
    * Lambda maximums are increased.
-   * (_split.maxChunkDurationInSeconds must be set in your script if you want to use values up to this length)
+   * (_split.maxChunkDurationInSeconds must be set in your script if you want to use values up to this duration)
    */
   MAX_CHUNK_DURATION_IN_SECONDS: 285, // 4 minutes and 45 seconds (allow for 15 second alignment time)
   /**
@@ -53,7 +53,7 @@ const constants = {
   DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND: 25,
   /**
    * The hard coded maximum number of seconds to wait for your functions to start producing load.
-   * (_split.timeBufferInMilliseconds must be set in your script if you want to use values up to this length)
+   * (_split.timeBufferInMilliseconds must be set in your script if you want to use values up to this duration)
    */
   MAX_TIME_BUFFER_IN_MILLISECONDS: 30000,
   /**
@@ -125,7 +125,7 @@ const impl = {
    * @param phase The phase to obtain duration from.
    * @returns {number} The duration of the given phase in seconds.  If a duration cannot be obtained -1 is returned.
    */
-  phaseLength: (phase) => {
+  phaseDurationInSeconds: (phase) => {
     if ('duration' in phase) {
       return phase.duration
     } else if ('pause' in phase) {
@@ -139,20 +139,20 @@ const impl = {
    * the index of that phase, multiplied by -1, will be returned.  This way a result less than zero result can
    * easily be differentiated from a valid duration and the offending phase can be identified.
    * @param script The script to identify a total duration for.
-   * @returns {number} The total duration for the given script.  If any phases do not contain a valid duration,
+   * @returns {number} The total duration in seconds for the given script.  If any phases do not contain a valid duration,
    * the index of the first phase without a valid duration will be returned, multiplied by -1.
    */
-  scriptLength: (script) => {
+  scriptDurationInSeconds: (script) => {
     let ret = 0
     let i
-    let phaseLength
+    let phaseDurationInSeconds
     for (i = 0; i < script.config.phases.length; i++) {
-      phaseLength = impl.phaseLength(script.config.phases[i])
-      if (phaseLength < 0) {
+      phaseDurationInSeconds = impl.phaseDurationInSeconds(script.config.phases[i])
+      if (phaseDurationInSeconds < 0) {
         ret = -1 * i
         break
       } else {
-        ret += phaseLength
+        ret += phaseDurationInSeconds
       }
     }
     return ret
@@ -162,7 +162,7 @@ const impl = {
    * @param phase The phase to obtain specified requests per second from.
    * @returns The specified requests per second of a phase.  If a valid specification is not available, -1 is returned.
    */
-  phaseWidth: (phase) => {
+  phaseRequestsPerSecond: (phase) => {
     if ('rampTo' in phase && 'arrivalRate' in phase) {
       return Math.max(phase.arrivalRate, phase.rampTo)
     } else if ('arrivalRate' in phase) {
@@ -176,14 +176,15 @@ const impl = {
     }
   },
   /**
-   * Calculate the maximum width of a script in RPS.  If a phase does not have a valid width, the index of that
-   * phase, multiplied by -1, will be returned.  This way a result less than zero result can easily be
-   * differentiated from a valid width and the offending phase can be identified.
+   * Calculate the maximum requests per second specified by a script.  If a phase does not have a valid requests per second,
+   * the index of that phase, multiplied by -1, will be returned.  This way a result less than zero result can easily be
+   * differentiated from a valid requests per second and the offending phase can be identified.
    *
-   * @param script The script to identify a maximum width for.
-   * @returns {number} The width of the script in RPS (Requests Per Second) or -1 if an invalid phase is encountered.
+   * @param script The script to identify a maximum requests per second for.
+   * @returns {number} The requests per second specified by the script or -i if an invalid phase is encountered,
+   * where i is the zero based index of the phase containing an invalid requests per second value.
    */
-  scriptWidth: (script) => {
+  scriptRequestsPerSecond: (script) => {
     /*
      * See https://artillery.io/docs/script_reference.html#phases for phase types.
      *
@@ -195,14 +196,14 @@ const impl = {
      */
     let ret = 0
     let i
-    let phaseWidth
+    let phaseRequestsPerSecond
     for (i = 0; i < script.config.phases.length; i++) {
-      phaseWidth = impl.phaseWidth(script.config.phases[i])
-      if (phaseWidth < 0) {
+      phaseRequestsPerSecond = impl.phaseRequestsPerSecond(script.config.phases[i])
+      if (phaseRequestsPerSecond < 0) {
         ret = -1 * i
         break
       } else {
-        ret = Math.max(ret, phaseWidth)
+        ret = Math.max(ret, phaseRequestsPerSecond)
       }
     }
     return ret
@@ -216,8 +217,8 @@ const impl = {
    */
   validScript: (script, context, callback) => {
     let ret = false
-    let scriptLength
-    let scriptWidth
+    let scriptDurationInSeconds
+    let scriptRequestsPerSecond
     const settings = impl.getSettings(script)
     // Splitting Settings [Optional]
     if (script._split && typeof script._split !== 'object') {
@@ -228,7 +229,7 @@ const impl = {
       settings.maxChunkDurationInSeconds > 0 &&
       settings.maxChunkDurationInSeconds <= constants.MAX_CHUNK_DURATION_IN_SECONDS)
     ) {
-      callback('If specified the "_split.maxChunkDuration" attribute must be an integer inclusively between ' +
+      callback('If specified the "_split.maxChunkDurationInSeconds" attribute must be an integer inclusively between ' +
         `1 and ${constants.MAX_CHUNK_DURATION_IN_SECONDS}.`)
     } else if (
       settings.maxScriptDurationInSeconds &&
@@ -236,7 +237,7 @@ const impl = {
       settings.maxScriptDurationInSeconds > 0 &&
       settings.maxScriptDurationInSeconds <= constants.MAX_SCRIPT_DURATION_IN_SECONDS)
     ) {
-      callback('If specified the "_split.maxScriptDuration" attribute must be an integer inclusively between ' +
+      callback('If specified the "_split.maxScriptDurationInSeconds" attribute must be an integer inclusively between ' +
       `1 and ${constants.MAX_SCRIPT_DURATION_IN_SECONDS}.`)
     } else if (
       settings.maxChunkRequestsPerSecond &&
@@ -283,19 +284,19 @@ const impl = {
           .join('", "')
       }"`)
     } else if (!(script.mode === constants.modes.ACC || script.mode === constants.modes.ACCEPTANCE)) {
-      scriptLength = impl.scriptLength(script) // determine length and width
-      scriptWidth = impl.scriptWidth(script)
-      if (scriptLength < 0) {
-        callback(`Every phase must have a valid duration.  Observed: ${
-          JSON.stringify(script.config.phases[scriptLength * -1])
+      scriptDurationInSeconds = impl.scriptDurationInSeconds(script)
+      scriptRequestsPerSecond = impl.scriptRequestsPerSecond(script)
+      if (scriptDurationInSeconds < 0) {
+        callback(`Every phase must have a valid duration in seconds.  Observed: ${
+          JSON.stringify(script.config.phases[scriptDurationInSeconds * -1])
         }`)
-      } else if (scriptLength > settings.maxScriptDurationInSeconds) {
-        callback(`The total duration of all script phases cannot exceed ${settings.maxScriptDurationInSeconds}`)
-      } else if (scriptWidth < 0) {
+      } else if (scriptDurationInSeconds > settings.maxScriptDurationInSeconds) {
+        callback(`The total duration in seconds of all script phases cannot exceed ${settings.maxScriptDurationInSeconds}`)
+      } else if (scriptRequestsPerSecond < 0) {
         callback(`Every phase must have a valid means to determine requests per second.  Observed: ${
-          JSON.stringify(script.config.phases[scriptWidth * -1])
+          JSON.stringify(script.config.phases[scriptRequestsPerSecond * -1])
         }`)
-      } else if (scriptWidth > settings.maxScriptRequestsPerSecond) {
+      } else if (scriptRequestsPerSecond > settings.maxScriptRequestsPerSecond) {
         callback(`The maximum requests per second of any script phase cannot exceed ${
           settings.maxScriptRequestsPerSecond
         }`)
@@ -310,10 +311,10 @@ const impl = {
   /**
    * Split the given phase along the time dimension so that the resulting chunk is no longer than the given chunkSize
    * @param phase The phase to split so that the produced chunk is no more than chunkSize seconds long
-   * @param chunkSize The length, in seconds, that the chunk removed from the phase should be no longer than
-   * @returns {{chunk, remainder: *}} The chunk that is chunkSize length and the remainder of the phase.
+   * @param chunkSize The duration, in seconds, that the chunk removed from the phase should be no longer than
+   * @returns {{chunk, remainder: *}} The chunk that is chunkSize duration and the remainder of the phase.
    */
-  splitPhaseByLength: (phase, chunkSize) => {
+  splitPhaseByDurationInSeconds: (phase, chunkSize) => {
     const ret = {
       chunk: JSON.parse(JSON.stringify(phase)),
       remainder: phase,
@@ -347,33 +348,33 @@ const impl = {
   /**
    * Split the given script along the time dimension so that the resulting chunk is no longer than the given chunkSize
    * @param script The script to split so that the produced chunk is no more than chunkSize seconds long
-   * @param chunkSize The length, in seconds, that the chunk removed from the script should be no longer than
-   * @returns {{chunk, remainder: *}} The chunk that is chunkSize length and the remainder of the script.
+   * @param chunkSize The duration, in seconds, that the chunk removed from the script should be no longer than
+   * @returns {{chunk, remainder: *}} The chunk that is chunkSize duration and the remainder of the script.
    */
-  splitScriptByLength: (script, chunkSize) => {
+  splitScriptByDurationInSeconds: (script, chunkSize) => {
     const ret = {
       chunk: JSON.parse(JSON.stringify(script)),
       remainder: script,
     }
-    let remainingDuration = chunkSize
+    let remainingDurationInSeconds = chunkSize
     let phase
-    let phaseLength
+    let phaseDurationInSeconds
     let phaseParts
     ret.chunk.config.phases = []
     if (ret.remainder._start) {
       delete ret.remainder._start
     }
-    while (remainingDuration > 0 && ret.remainder.config.phases.length) {
+    while (remainingDurationInSeconds > 0 && ret.remainder.config.phases.length) {
       phase = ret.remainder.config.phases.shift()
-      phaseLength = impl.phaseLength(phase)
-      if (phaseLength > remainingDuration) { // split phase
-        phaseParts = impl.splitPhaseByLength(phase, remainingDuration)
+      phaseDurationInSeconds = impl.phaseDurationInSeconds(phase)
+      if (phaseDurationInSeconds > remainingDurationInSeconds) { // split phase
+        phaseParts = impl.splitPhaseByDurationInSeconds(phase, remainingDurationInSeconds)
         ret.chunk.config.phases.push(phaseParts.chunk)
         ret.remainder.config.phases.unshift(phaseParts.remainder)
-        remainingDuration = 0
+        remainingDurationInSeconds = 0
       } else {
         ret.chunk.config.phases.push(phase)
-        remainingDuration -= phaseLength
+        remainingDurationInSeconds -= phaseDurationInSeconds
       }
     }
     return ret
@@ -512,7 +513,7 @@ const impl = {
    * @returns {*} {{chunk, remainder: *}} The chunk that is at most chunkSize requests per second and the
    * remainder of the pahse.
    */
-  splitPhaseByWidth: (phase, chunkSize) => {
+  splitPhaseByRequestsPerSecond: (phase, chunkSize) => {
     const ret = {
       chunk: [],
       remainder: [],
@@ -589,15 +590,15 @@ const impl = {
     return ret
   },
   /**
-   * Split a script by width because it specifies a requests per second load in excess of chunkSize
-   * Split the given script by width since it is too wide to run on a single lambda.  Do this by chunking off
-   * the maximum RPS a single lambda can handle.
-   * @param script The script to split by width
-   * @param chunkSize The maximum width of any phase
+   * Split the given script in to a chunk of the given maximum size in requests per second and a remainder.  This is
+   * usually done because the script specifies too much load to produce from a single function.  Do this by chunking
+   * off the maximum RPS a single function can handle.
+   * @param script The script to split off a chunk with the given maximum requests per second
+   * @param chunkSize The maximum requests per second of any phase
    * @returns {{chunk, remainder}} The Lambda-sized chunk that was removed from the script and the remaining
    * script to execute
    */
-  splitScriptByWidth: (script, chunkSize) => {
+  splitScriptByRequestsPerSecond: (script, chunkSize) => {
     const ret = {
       chunk: JSON.parse(JSON.stringify(script)),
       remainder: JSON.parse(JSON.stringify(script)),
@@ -608,7 +609,7 @@ const impl = {
     ret.chunk.config.phases = []
     ret.remainder.config.phases = []
     for (i = 0; i < script.config.phases.length; i++) {
-      phaseParts = impl.splitPhaseByWidth(script.config.phases[i], chunkSize)
+      phaseParts = impl.splitPhaseByRequestsPerSecond(script.config.phases[i], chunkSize)
       for (j = 0; j < phaseParts.chunk.length; j++) {
         ret.chunk.config.phases.push(phaseParts.chunk[j])
       }
@@ -832,8 +833,8 @@ const impl = {
     let timeDelay
     let exec
     const settings = impl.getSettings(script)
-    const scriptDuration = impl.scriptLength(script)
-    let scriptWidth = impl.scriptWidth(script)
+    const scriptDurationInSeconds = impl.scriptDurationInSeconds(script)
+    let scriptRequestsPerSecond = impl.scriptRequestsPerSecond(script)
     toComplete = 1
     console.log(`toComplete: ${toComplete} in ${timeNow} (init)`)
     const complete = () => {
@@ -853,23 +854,23 @@ const impl = {
     }
     // if there is more script to execute than we're willing to execute in a single chunk, chomp off a
     // chunk, execute and create an extension.
-    if (scriptDuration > settings.maxChunkDurationInSeconds) {
+    if (scriptDurationInSeconds > settings.maxChunkDurationInSeconds) {
       if (script._trace) {
-        console.log(`splitting script by length from ${script._genesis} in ${timeNow} @ ${Date.now()}`)
+        console.log(`splitting script by duration from ${script._genesis} in ${timeNow} @ ${Date.now()}`)
       }
       toComplete = 2
-      parts = impl.splitScriptByLength(script, settings.maxChunkDurationInSeconds)
+      parts = impl.splitScriptByDurationInSeconds(script, settings.maxChunkDurationInSeconds)
       if (!parts.chunk._start) {
         parts.chunk._start = timeNow + settings.timeBufferInMilliseconds
       }
       // kick the reminder off timeBufferInMilliseconds ms before the end of the chunk's completion
       parts.remainder._start = parts.chunk._start + (settings.maxChunkDurationInSeconds * 1000)
-      scriptWidth = impl.scriptWidth(parts.chunk)
+      scriptRequestsPerSecond = impl.scriptRequestsPerSecond(parts.chunk)
       if (script._trace) {
         console.log(`scheduling shortened chunk start from ${
           script._genesis} in ${timeNow} for execution @ ${parts.chunk._start}`)
       }
-      if (scriptWidth > settings.maxChunkRequestsPerSecond) { // needs splitting by width too
+      if (scriptRequestsPerSecond > settings.maxChunkRequestsPerSecond) { // needs splitting by requestsPerSecond too
         impl.runPerformance(timeNow, parts.chunk, context, complete)
       } else { // otherwise, send to a separate lambda for execution
         impl.invokeSelf( // eslint-disable-next-line comma-dangle
@@ -887,16 +888,16 @@ const impl = {
       )
       // otherwise, if the script is too wide for a single Lambda to execute, chunk off executable chunks and
       // send them to Lambdas for execution
-    } else if (scriptWidth > settings.maxChunkRequestsPerSecond) {
+    } else if (scriptRequestsPerSecond > settings.maxChunkRequestsPerSecond) {
       if (script._trace) {
-        console.log(`splitting script by width from ${script._genesis} in ${timeNow} @ ${Date.now()}`)
+        console.log(`splitting script by requests per second from ${script._genesis} in ${timeNow} @ ${Date.now()}`)
       }
       if (!script._start) {
         script._start = timeNow + settings.timeBufferInMilliseconds // eslint-disable-line no-param-reassign
       }
-      toComplete = Math.ceil(scriptWidth / settings.maxChunkRequestsPerSecond)
+      toComplete = Math.ceil(scriptRequestsPerSecond / settings.maxChunkRequestsPerSecond)
       do {
-        parts = impl.splitScriptByWidth(script, settings.maxChunkRequestsPerSecond)
+        parts = impl.splitScriptByRequestsPerSecond(script, settings.maxChunkRequestsPerSecond)
         console.log(JSON.stringify(parts.chunk, null, 2))
         // send the chunk
         impl.invokeSelf( // eslint-disable-next-line comma-dangle
@@ -904,8 +905,8 @@ const impl = {
         )
         // determine whether we need to continue chunking
         script = parts.remainder // eslint-disable-line no-param-reassign
-        scriptWidth = impl.scriptWidth(script)
-      } while (scriptWidth > 0)
+        scriptRequestsPerSecond = impl.scriptRequestsPerSecond(script)
+      } while (scriptRequestsPerSecond > 0)
     } else {
       if (!script._start) {
         script._start = timeNow // eslint-disable-line no-param-reassign
@@ -995,8 +996,8 @@ const impl = {
 const api = {
   /**
    * This Lambda produces load according to the given specification.
-   * If that load exceeds the limits that a Lambda can individually satisfy (duration or requests per second) then
-   * the script will be split into chunks that can be executed by single lambdas and those will be executed.  If
+   * If that load exceeds the limits that a Lambda can individually satisfy (duration in seconds or requests per second)
+   * then the script will be split into chunks that can be executed by single lambdas and those will be executed.  If
    * the script can be run within a single Lambda then the results of that execution will be returned as the
    * result of the lambda invocation.
    * @param event The event specifying an Artillery load generation test to perform

--- a/tests/lib/index.spec.js
+++ b/tests/lib/index.spec.js
@@ -223,8 +223,8 @@ describe('serverless-artillery commands', function slsartCommands() { // eslint-
 
   describe('#exports.invoke', () => {
     const completeMessage = `${os.EOL}\tYour function invocation has completed.${os.EOL}`
-    const willCompleteMessage = length => `${os.EOL
-    }\tYour function has been invoked. The load is scheduled to be completed in ${length} seconds.${os.EOL}`
+    const willCompleteMessage = durationInSeconds => `${os.EOL
+    }\tYour function has been invoked. The load is scheduled to be completed in ${durationInSeconds} seconds.${os.EOL}`
 
     const replaceImpl = (scriptExtentResult, serverlessRunnerResult, func) => (() => {
       const scriptExtent = slsart.impl.scriptExtent
@@ -260,7 +260,7 @@ describe('serverless-artillery commands', function slsartCommands() { // eslint-
     describe('performance mode', () => {
       it('indicates function completeness and results (when the script can be excuted by one function)',
         replaceImpl(
-          { width: 1, length: 1, maxLength: 2, maxWidth: 2 },
+          { requestsPerSecond: 1, durationInSeconds: 1, maxRequestsPerSecond: 2, maxDurationInSeconds: 2 },
           {},
           () => slsart.invoke({ d: testJsonScriptStringified })
             .then(() => expect(logs[1]).to.eql(completeMessage)) // eslint-disable-line comma-dangle
@@ -268,7 +268,7 @@ describe('serverless-artillery commands', function slsartCommands() { // eslint-
       )
       it('reports future completion estimate (when script must be distributed across functions)',
         replaceImpl(
-          { width: 1, length: 3, maxLength: 2, maxWidth: 2 },
+          { requestsPerSecond: 1, durationInSeconds: 3, maxRequestsPerSecond: 2, maxDurationInSeconds: 2 },
           {},
           () => slsart.invoke({ d: testJsonScriptStringified })
             .then(() => expect(logs[1]).to.eql(willCompleteMessage(3))) // eslint-disable-line comma-dangle
@@ -278,7 +278,7 @@ describe('serverless-artillery commands', function slsartCommands() { // eslint-
     describe('acceptance mode', () => {
       it('adds `mode: \'acc\' to the script',
         replaceImpl(
-          { width: 1, length: 3, maxLength: 2, maxWidth: 2 },
+          { requestsPerSecond: 1, durationInSeconds: 3, maxRequestsPerSecond: 2, maxDurationInSeconds: 2 },
           {},
           () => slsart.invoke({ acceptance: true, d: testJsonScriptStringified })
             .then(() => expect(logs[1]).to.eql(completeMessage)) // eslint-disable-line comma-dangle
@@ -286,7 +286,7 @@ describe('serverless-artillery commands', function slsartCommands() { // eslint-
       )
       it('respects scripts declaring acceptance mode',
         replaceImpl(
-          { width: 1, length: 3, maxLength: 2, maxWidth: 2 },
+          { requestsPerSecond: 1, durationInSeconds: 3, maxRequestsPerSecond: 2, maxDurationInSeconds: 2 },
           {},
           () => {
             const script = JSON.parse(testJsonScriptStringified)
@@ -298,7 +298,7 @@ describe('serverless-artillery commands', function slsartCommands() { // eslint-
       )
       it('reports acceptance test results to the console',
         replaceImpl(
-          { width: 1, length: 1, maxLength: 2, maxWidth: 2 },
+          { requestsPerSecond: 1, durationInSeconds: 1, maxRequestsPerSecond: 2, maxDurationInSeconds: 2 },
           { foo: 'bar' },
           () => {
             const script = JSON.parse(testJsonScriptStringified)
@@ -312,7 +312,7 @@ describe('serverless-artillery commands', function slsartCommands() { // eslint-
       )
       it('exits the process with a non-zero exit code when an error occurs during the acceptance test',
         replaceImpl(
-          { width: 1, length: 1, maxLength: 2, maxWidth: 2 },
+          { requestsPerSecond: 1, durationInSeconds: 1, maxRequestsPerSecond: 2, maxDurationInSeconds: 2 },
           { errors: 1, reports: [{ errors: 1 }] },
           () => {
             // save/replace process.exit

--- a/tests/lib/lambda/handler.spec.js
+++ b/tests/lib/lambda/handler.spec.js
@@ -24,14 +24,14 @@ describe('serverless-artillery Handler Tests', () => {
       expect(handler.impl.getSettings(script)).to.eql(script._split) // eslint-disable-line no-underscore-dangle
     })
   })
-  describe('#impl.phaseLength', () => {
+  describe('#impl.phaseDurationInSeconds', () => {
     // /**
     //  * Obtain the duration of a phase in seconds.
     //  * @param phase The phase to obtain duration from.
     //  * @returns {number} The duration of the given phase in seconds.  If a duration cannot be obtained -1 is
     //  * returned.
     //  */
-    // phaseLength: (phase) => {
+    // phaseDurationInSeconds: (phase) => {
     //   if ('duration' in phase) {
     //     return phase.duration;
     //   } else if ('pause' in phase) {
@@ -40,11 +40,11 @@ describe('serverless-artillery Handler Tests', () => {
     //     return -1;
     //   }
     // }
-    it('extracts the length of a duration phase', () => {
+    it('extracts the duration of a duration phase', () => {
       // TODO implement tests
     })
   })
-  describe('#impl.scriptLength', () => {
+  describe('#impl.scriptDurationInSeconds', () => {
     // /**
     //  * Calculate the total duration of the Artillery script in seconds.  If a phase does not have a valid duration,
     //  * the index of that phase, multiplied by -1, will be returned.  This way a result less than zero result can
@@ -53,17 +53,17 @@ describe('serverless-artillery Handler Tests', () => {
     //  * @returns {number} The total duration for the given script.  If any phases do not contain a valid duration,
     //  * the index of the first phase without a valid duration will be returned, multiplied by -1.
     //  */
-    // scriptLength: (script) => {
+    // scriptDurationInSeconds: (script) => {
     //   let ret = 0;
     //   let i;
-    //   let phaseLength;
+    //   let phaseDurationInSeconds;
     //   for (i = 0; i < script.config.phases.length; i++) {
-    //     phaseLength = impl.phaseLength(script.config.phases[i]);
-    //     if (phaseLength < 0) {
+    //     phaseDurationInSeconds = impl.phaseDurationInSeconds(script.config.phases[i]);
+    //     if (phaseDurationInSeconds < 0) {
     //       ret = -1 * i;
     //       break;
     //     } else {
-    //       ret += phaseLength;
+    //       ret += phaseDurationInSeconds;
     //     }
     //   }
     //   return ret;
@@ -72,14 +72,14 @@ describe('serverless-artillery Handler Tests', () => {
       // TODO implement tests
     })
   })
-  describe('#impl.phaseWidth', () => {
+  describe('#impl.phaseRequestsPerSecond', () => {
     // /**
     //  * Obtain the specified requests per second of a phase.
     //  * @param phase The phase to obtain specified requests per second from.
     //  * @returns The specified requests per second of a phase.  If a valid specification is not available, -1 is
     //  * returned.
     //  */
-    // phaseWidth: (phase) => {
+    // phaseRequestsPerSecond: (phase) => {
     //   if ('rampTo' in phase && 'arrivalRate' in phase) {
     //     return Math.max(phase.arrivalRate, phase.rampTo);
     //   } else if ('arrivalRate' in phase) {
@@ -96,17 +96,17 @@ describe('serverless-artillery Handler Tests', () => {
       // TODO implement tests
     })
   })
-  describe('#impl.scriptWidth', () => {
+  describe('#impl.scriptRequestsPerSecond', () => {
     // /**
-    //  * Calculate the maximum width of a script in RPS.  If a phase does not have a valid width, the index of that
+    //  * Calculate the maximum requestsPerSecond of a script in RPS.  If a phase does not have a valid requestsPerSecond, the index of that
     //  * phase, multiplied by -1, will be returned.  This way a result less than zero result can easily be
-    //  * differentiated from a valid width and the offending phase can be identified.
+    //  * differentiated from a valid requestsPerSecond and the offending phase can be identified.
     //  *
-    //  * @param script The script to identify a maximum width for.
-    //  * @returns {number} The width of the script in RPS (Requests Per Second) or -1 if an invalid phase is
+    //  * @param script The script to identify a maximum requestsPerSecond for.
+    //  * @returns {number} The requestsPerSecond of the script in RPS (Requests Per Second) or -1 if an invalid phase is
     //  * encountered.
     //  */
-    // scriptWidth: (script) => {
+    // scriptRequestsPerSecond: (script) => {
     //   /*
     //    * See https://artillery.io/docs/script_reference.html#phases for phase types.
     //    *
@@ -118,14 +118,14 @@ describe('serverless-artillery Handler Tests', () => {
     //    */
     //   let ret = 0;
     //   let i;
-    //   let phaseWidth;
+    //   let phaseRequestsPerSecond;
     //   for (i = 0; i < script.config.phases.length; i++) {
-    //     phaseWidth = impl.phaseWidth(script.config.phases[i]);
-    //     if (phaseWidth < 0) {
+    //     phaseRequestsPerSecond = impl.phaseRequestsPerSecond(script.config.phases[i]);
+    //     if (phaseRequestsPerSecond < 0) {
     //       ret = -1 * i;
     //       break;
     //     } else {
-    //       ret = Math.max(ret, phaseWidth);
+    //       ret = Math.max(ret, phaseRequestsPerSecond);
     //     }
     //   }
     //   return ret;
@@ -145,8 +145,8 @@ describe('serverless-artillery Handler Tests', () => {
       //  */
       // validScript: (script, context, callback) => {
       //   let ret = false;
-      //   let scriptLength;
-      //   let scriptWidth;
+      //   let scriptDurationInSeconds;
+      //   let scriptRequestsPerSecond;
       //   const settings = impl.getSettings(script);
       //   // Splitting Settings [Optional]
       //   if (script._split && typeof script._split !== 'object') {
@@ -157,7 +157,7 @@ describe('serverless-artillery Handler Tests', () => {
       //     settings.maxChunkDurationInSeconds > 0 &&
       //     settings.maxChunkDurationInSeconds <= constants.MAX_CHUNK_DURATION_IN_SECONDS)
       //   ) {
-      //     callback('If specified the "_split.maxChunkDuration" attribute must be an integer inclusively between ' +
+      //     callback('If specified the "_split.maxChunkDurationInSeconds" attribute must be an integer inclusively between ' +
       //       `1 and ${constants.MAX_CHUNK_DURATION_IN_SECONDS}.`);
       //   } else if (
       //     settings.maxScriptDurationInSeconds &&
@@ -165,7 +165,7 @@ describe('serverless-artillery Handler Tests', () => {
       //     settings.maxScriptDurationInSeconds > 0 &&
       //     settings.maxScriptDurationInSeconds <= constants.MAX_SCRIPT_DURATION_IN_SECONDS)
       //   ) {
-      //     callback('If specified the "_split.maxScriptDuration" attribute must be an integer inclusively between ' +
+      //     callback('If specified the "_split.maxScriptDurationInSeconds" attribute must be an integer inclusively between ' +
       //       `1 and ${constants.MAX_SCRIPT_DURATION_IN_SECONDS}.`);
       //   } else if (
       //     settings.maxChunkRequestsPerSecond &&
@@ -212,19 +212,19 @@ describe('serverless-artillery Handler Tests', () => {
       //         .join('", "')
       //       }"`);
       //   } else if (!(script.mode === constants.modes.ACC || script.mode === constants.modes.ACCEPTANCE)) {
-      //     scriptLength = impl.scriptLength(script); // determine length and width
-      //     scriptWidth = impl.scriptWidth(script);
-      //     if (scriptLength < 0) {
+      //     scriptDurationInSeconds = impl.scriptDurationInSeconds(script); // determine durationInSeconds and requestsPerSecond
+      //     scriptRequestsPerSecond = impl.scriptRequestsPerSecond(script);
+      //     if (scriptDurationInSeconds < 0) {
       //       callback(`Every phase must have a valid duration.  Observed: ${
-      //         JSON.stringify(script.config.phases[scriptLength * -1])
+      //         JSON.stringify(script.config.phases[scriptDurationInSeconds * -1])
       //         }`);
-      //     } else if (scriptLength > settings.maxScriptDurationInSeconds) {
+      //     } else if (scriptDurationInSeconds > settings.maxScriptDurationInSeconds) {
       //       callback(`The total duration of all script phases cannot exceed ${settings.maxScriptDurationInSeconds}`);
-      //     } else if (scriptWidth < 0) {
+      //     } else if (scriptRequestsPerSecond < 0) {
       //       callback(`Every phase must have a valid means to determine requests per second.  Observed: ${
-      //         JSON.stringify(script.config.phases[scriptWidth * -1])
+      //         JSON.stringify(script.config.phases[scriptRequestsPerSecond * -1])
       //         }`);
-      //     } else if (scriptWidth > settings.maxScriptRequestsPerSecond) {
+      //     } else if (scriptRequestsPerSecond > settings.maxScriptRequestsPerSecond) {
       //       callback(`The maximum requests per second of any script phase cannot exceed ${
       //         settings.maxScriptRequestsPerSecond
       //         }`);
@@ -240,10 +240,10 @@ describe('serverless-artillery Handler Tests', () => {
     })
   })
   /**
-   * SPLIT PHASE BY LENGTH
+   * SPLIT PHASE BY DurationInSeconds
    */
-  describe('#impl.splitPhaseByLength splits PHASES that are TOO LONG', () => {
-    it('splitting a constant rate phase of three chunk\'s length into two parts.', () => {
+  describe('#impl.splitPhaseByDurationInSeconds splits PHASES that are TOO LONG', () => {
+    it('splitting a constant rate phase of three chunk\'s durationInSeconds into two parts.', () => {
       phase = {
         duration: 3 * handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS,
         arrivalRate: 1,
@@ -258,10 +258,10 @@ describe('serverless-artillery Handler Tests', () => {
           arrivalRate: 1,
         },
       }
-      result = handler.impl.splitPhaseByLength(phase, handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS)
+      result = handler.impl.splitPhaseByDurationInSeconds(phase, handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS)
       expect(result).to.deep.equal(expected)
     })
-    it('splitting a ramping phase of two chunk\'s length into two parts.', () => {
+    it('splitting a ramping phase of two chunk\'s duration into two parts.', () => {
       phase = {
         duration: 3 * handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS,
         arrivalRate: 1,
@@ -279,10 +279,10 @@ describe('serverless-artillery Handler Tests', () => {
           rampTo: 4,
         },
       }
-      result = handler.impl.splitPhaseByLength(phase, handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS)
+      result = handler.impl.splitPhaseByDurationInSeconds(phase, handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS)
       expect(result).to.deep.equal(expected)
     })
-    it('splits ramp of two chunk\'s length into two parts, rounding to the nearest integer rate per second.', () => {
+    it('splits ramp of two chunk\'s duration into two parts, rounding to the nearest integer rate per second.', () => {
       phase = {
         duration: 2 * handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS,
         arrivalRate: 1,
@@ -300,10 +300,10 @@ describe('serverless-artillery Handler Tests', () => {
           rampTo: 2,
         },
       }
-      result = handler.impl.splitPhaseByLength(phase, handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS)
+      result = handler.impl.splitPhaseByDurationInSeconds(phase, handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS)
       expect(result).to.deep.equal(expected)
     })
-    it('splitting an arrival count phase of two chunk\'s length into two parts.', () => {
+    it('splitting an arrival count phase of two chunk\'s duration into two parts.', () => {
       phase = {
         duration: 2 * handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS,
         arrivalCount: 2 * handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS,
@@ -318,10 +318,10 @@ describe('serverless-artillery Handler Tests', () => {
           arrivalCount: handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS,
         },
       }
-      result = handler.impl.splitPhaseByLength(phase, handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS)
+      result = handler.impl.splitPhaseByDurationInSeconds(phase, handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS)
       expect(result).to.deep.equal(expected)
     })
-    it('splitting a pause phase of two chunk\'s length into two parts.', () => {
+    it('splitting a pause phase of two chunk\'s duration into two parts.', () => {
       phase = {
         pause: 2 * handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS,
       }
@@ -333,14 +333,14 @@ describe('serverless-artillery Handler Tests', () => {
           pause: handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS,
         },
       }
-      result = handler.impl.splitPhaseByLength(phase, handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS)
+      result = handler.impl.splitPhaseByDurationInSeconds(phase, handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS)
       expect(result).to.deep.equal(expected)
     })
   })
   /**
-   * SPLIT SCRIPT BY LENGTH
+   * SPLIT SCRIPT BY DURATION
    */
-  describe('#impl.splitScriptByLength The handler splits SCRIPTS that are TOO LONG', () => {
+  describe('#impl.splitScriptByDurationInSeconds The handler splits SCRIPTS that are TOO LONG', () => {
     it('splitting a script where there is a natural phase split at MAX_CHUNK_DURATION between two phases.', () => {
       script = {
         config: {
@@ -378,7 +378,7 @@ describe('serverless-artillery Handler Tests', () => {
           },
         },
       }
-      result = handler.impl.splitScriptByLength(script, handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS)
+      result = handler.impl.splitScriptByDurationInSeconds(script, handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS)
       expect(result).to.deep.equal(expected)
     })
     it('splitting a script where there is a natural phase split at MAX_CHUNK_DURATION between many phases.', () => {
@@ -442,7 +442,7 @@ describe('serverless-artillery Handler Tests', () => {
           },
         },
       }
-      result = handler.impl.splitScriptByLength(script, handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS)
+      result = handler.impl.splitScriptByDurationInSeconds(script, handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS)
       expect(result).to.deep.equal(expected)
     })
     it('splitting a script where a phase must be split at MAX_CHUNK_DURATION.', () => {
@@ -494,14 +494,14 @@ describe('serverless-artillery Handler Tests', () => {
           },
         },
       }
-      result = handler.impl.splitScriptByLength(script, handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS)
+      result = handler.impl.splitScriptByDurationInSeconds(script, handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS)
       expect(result).to.deep.equal(expected)
     })
   })
   /**
-   * SPLIT PHASE BY WIDTH
+   * SPLIT PHASE BY RequestsPerSecond
    */
-  describe('#impl.splitPhaseByWidth The handler splits PHASES that are TOO WIDE (RPS > MAX_RPS)', () => {
+  describe('#impl.splitPhaseByRequestsPerSecond The handler splits PHASES that are TOO WIDE (RPS > MAX_RPS)', () => {
     // min >= chunkSize
     it('splitting a ramp phase that at all times exceeds a rate of DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND into a' +
       ' constant rate and remainder ramp phases.', () => {
@@ -525,7 +525,7 @@ describe('serverless-artillery Handler Tests', () => {
           },
         ],
       }
-      result = handler.impl.splitPhaseByWidth(phase, handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND)
+      result = handler.impl.splitPhaseByRequestsPerSecond(phase, handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND)
       expect(result).to.deep.equal(expected)
     })
     // max <= chunkSize
@@ -550,7 +550,7 @@ describe('serverless-artillery Handler Tests', () => {
           },
         ],
       }
-      result = handler.impl.splitPhaseByWidth(phase, handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND)
+      result = handler.impl.splitPhaseByRequestsPerSecond(phase, handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND)
       expect(result).to.deep.equal(expected)
     })
     it('splitting an ascending ramp phase that starts lower than and ends higher than' +
@@ -584,7 +584,7 @@ describe('serverless-artillery Handler Tests', () => {
           },
         ],
       }
-      result = handler.impl.splitPhaseByWidth(phase, handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND)
+      result = handler.impl.splitPhaseByRequestsPerSecond(phase, handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND)
       expect(result).to.deep.equal(expected)
     })
     it('splitting a descending ramp phase that starts lower than and ends higher than' +
@@ -618,10 +618,10 @@ describe('serverless-artillery Handler Tests', () => {
           },
         ],
       }
-      result = handler.impl.splitPhaseByWidth(phase, handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND)
+      result = handler.impl.splitPhaseByRequestsPerSecond(phase, handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND)
       expect(result).to.deep.equal(expected)
     })
-    it('splits an arrivalRate of less than a chunk\'s width into a chunk of that width and remainder of pause', () => {
+    it('splits an arrivalRate of less than a chunk\'s requestsPerSecond into a chunk of that requestsPerSecond and remainder of pause', () => {
       phase = {
         arrivalRate: handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND * 0.75,
         duration: 1,
@@ -639,10 +639,10 @@ describe('serverless-artillery Handler Tests', () => {
           },
         ],
       }
-      result = handler.impl.splitPhaseByWidth(phase, handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND)
+      result = handler.impl.splitPhaseByRequestsPerSecond(phase, handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND)
       expect(result).to.deep.equal(expected)
     })
-    it('splitting an arrivalRate phase of two chunk\'s width into two parts.', () => {
+    it('splitting an arrivalRate phase of two chunk\'s requestsPerSecond into two parts.', () => {
       phase = {
         arrivalRate: handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND * 2,
         duration: 1,
@@ -661,10 +661,10 @@ describe('serverless-artillery Handler Tests', () => {
           },
         ],
       }
-      result = handler.impl.splitPhaseByWidth(phase, handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND)
+      result = handler.impl.splitPhaseByRequestsPerSecond(phase, handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND)
       expect(result).to.deep.equal(expected)
     })
-    it('splitting an arrivalCount phase of two chunk\'s width into two parts.', () => {
+    it('splitting an arrivalCount phase of two chunk\'s requestsPerSecond into two parts.', () => {
       phase = {
         arrivalCount: handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND * 2,
         duration: 1,
@@ -683,10 +683,10 @@ describe('serverless-artillery Handler Tests', () => {
           },
         ],
       }
-      result = handler.impl.splitPhaseByWidth(phase, handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND)
+      result = handler.impl.splitPhaseByRequestsPerSecond(phase, handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND)
       expect(result).to.deep.equal(expected)
     })
-    it('splitting an arrivalCount phase of less than chunkSize\'s width into an arrival count and pause phase.', () => {
+    it('splitting an arrivalCount phase of less than chunkSize\'s requestsPerSecond into an arrival count and pause phase.', () => {
       phase = {
         arrivalCount: handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND * 0.75,
         duration: 1,
@@ -704,7 +704,7 @@ describe('serverless-artillery Handler Tests', () => {
           },
         ],
       }
-      result = handler.impl.splitPhaseByWidth(phase, handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND)
+      result = handler.impl.splitPhaseByRequestsPerSecond(phase, handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND)
       expect(result).to.deep.equal(expected)
     })
     it('splitting a pause phase into two pause phases.', () => {
@@ -719,14 +719,14 @@ describe('serverless-artillery Handler Tests', () => {
           { pause: handler.constants.DEFAULT_MAX_CHUNK_DURATION_IN_SECONDS },
         ],
       }
-      result = handler.impl.splitPhaseByWidth(phase, handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND)
+      result = handler.impl.splitPhaseByRequestsPerSecond(phase, handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND)
       expect(result).to.deep.equal(expected)
     })
   })
   /**
-   * SPLIT SCRIPT BY WIDTH
+   * SPLIT SCRIPT BY RequestsPerSecond
    */
-  describe('#impl.splitScriptByWidth the handler splits SCRIPTS that are TOO WIDE', () => {
+  describe('#impl.splitScriptByRequestsPerSecond the handler splits SCRIPTS that are TOO WIDE', () => {
     it('splits a script with a phase that specifies twice DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND load.', () => {
       script = {
         config: {
@@ -760,7 +760,7 @@ describe('serverless-artillery Handler Tests', () => {
           },
         },
       }
-      result = handler.impl.splitScriptByWidth(script, handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND)
+      result = handler.impl.splitScriptByRequestsPerSecond(script, handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND)
       expect(result).to.deep.equal(expected)
     })
     it('splits a script of two phases that specify twice DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND load to split.', () => {
@@ -808,7 +808,7 @@ describe('serverless-artillery Handler Tests', () => {
           },
         },
       }
-      result = handler.impl.splitScriptByWidth(script, handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND)
+      result = handler.impl.splitScriptByRequestsPerSecond(script, handler.constants.DEFAULT_MAX_CHUNK_REQUESTS_PER_SECOND)
       expect(result).to.deep.equal(expected)
     })
   })


### PR DESCRIPTION
Fixes #83, #84, and #85.

The fix here:
https://github.com/Nordstrom/serverless-artillery/commit/7c1e56eac1de7729500f4746ed9401e775784521
missed the fact that a term confusion consistently used elsewhere was the use of settings was the driver of the issue being solved (sorry about that - maybe we should consider making length/width consistent with duration/RPS?).  Code changes elsewhere fell prey to the missed naming=>expectation causing the use of Event invocation type inappropriately.

Our injection into the call SLS path can improperly alter the SLS stack calls if it does not properly handle parse failures.  There may be more to do here to ensure that a parse failure doesn't cause acceptance of a bad result.  However, the case where this came up was when invoking the function with invocation type "Event" and the payload is the empty string.  Therefore, the bug resolution is to both check for a non-empty string but also to protect the parse with a try catch in order to avoid future issues.

The handler uses > to compare script extent to limits, the CLI should not use >=