### PR TITLE
Fix Duration Check Bug

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -130,7 +130,7 @@ const impl = {
     const ret = {
       durationInSeconds: handler.impl.scriptDurationInSeconds(script),
       requestsPerSecond: handler.impl.scriptRequestsPerSecond(script),
-      maxDurationInSeconds: settings.maxScriptDurationInSeconds,
+      maxDurationInSeconds: settings.maxChunkDurationInSeconds,
       maxRequestsPerSecond: settings.maxChunkRequestsPerSecond,
     }
     let httpTimeout = 119 // slightly less than default 2 minutes
@@ -141,8 +141,8 @@ const impl = {
     ) {
       httpTimeout = Math.floor(aws.config.httpOptions.timeout / 1000) - 1 // convert from ms to s and reduce by 1
     }
-    if (ret.maxRequestsPerSecond > httpTimeout) { // reset to avoid HTTP timeout rather than Lambda timeout
-      ret.maxRequestsPerSecond = httpTimeout
+    if (ret.maxDurationInSeconds > httpTimeout) { // reset to avoid HTTP timeout rather than Lambda timeout
+      ret.maxDurationInSeconds = httpTimeout
     }
     return ret
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-artillery",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-artillery",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A serverless performance testing tool. `serverless` + `artillery` = crush.  a.k.a. Orbital Laziers [sic]",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
The refactor of variable names was not properly validated against expected behavior.  As a result, the check for whether to use the RequestResponse invocation type instead of Event type fails to notice cases where the http timeout will be hit.  As a result, in those cases, the timeout is hit and the requester goes away, failing the lambda and causing retry (i.e. the load test runs twice).

Part of why this occurred is that we don't have a set of tests for script extent.  We recently vastly increased test coverage, this was something not tested.  I want this fix published before creating those tests.  The fix has been validated by a partner that was experiencing the issue.