### PR TITLE
Fix Duration Check Bug, Continued

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -121,28 +121,33 @@ const impl = {
     process.argv.push(JSON.stringify(script))
   },
   /**
-   * Get the extent and limits of the given script
-   * @param script The script to determine extent for
-   * @return {{durationInSeconds: (*|number), requestsPerSecond: (*|number), maxDurationInSeconds:(*|number), maxRequestsPerSecond: (*|number)}}
+   * Get the allowance for and requirement of the given script with regard to execution time
+   * @param script The script to determine allowance and requirements for
+   * @returns {{allowance: number, required: number}}
    */
-  scriptExtent(script) {
+  scriptConstraints(script) {
+    const networkBuffer = 2 // seconds to allow for network transmission
+    const resultsBuffer = 3 // seconds to allow for processing overhead (validation, decision making, results calculation)
     const settings = handler.impl.getSettings(script)
-    const ret = {
-      durationInSeconds: handler.impl.scriptDurationInSeconds(script),
-      requestsPerSecond: handler.impl.scriptRequestsPerSecond(script),
-      maxDurationInSeconds: settings.maxChunkDurationInSeconds,
-      maxRequestsPerSecond: settings.maxChunkRequestsPerSecond,
-    }
-    let httpTimeout = 119 // slightly less than default 2 minutes
+    const durationInSeconds = handler.impl.scriptDurationInSeconds(script)
+    const requestsPerSecond = handler.impl.scriptRequestsPerSecond(script)
+    let httpTimeout = 120 // default AWS setting
     if (
       aws.config &&
       aws.config.httpOptions &&
       'timeout' in aws.config.httpOptions
     ) {
-      httpTimeout = Math.floor(aws.config.httpOptions.timeout / 1000) - 1 // convert from ms to s and reduce by 1
+      httpTimeout = Math.floor(aws.config.httpOptions.timeout / 1000) // convert from ms to s
     }
-    if (ret.maxDurationInSeconds > httpTimeout) { // reset to avoid HTTP timeout rather than Lambda timeout
-      ret.maxDurationInSeconds = httpTimeout
+    const ret = {
+      allowance: Math.min(httpTimeout, settings.maxChunkDurationInSeconds) - networkBuffer,
+      required: durationInSeconds + resultsBuffer,
+    }
+    if (
+      durationInSeconds > settings.maxChunkDurationInSeconds ||
+      requestsPerSecond > settings.maxChunkRequestsPerSecond
+    ) { // if splitting happens, the time requirement is increased by timeBufferInMilliseconds
+      ret.required += Math.ceil(settings.timeBufferInMilliseconds / 1000) // convert from ms to s
     }
     return ret
   },
@@ -303,15 +308,11 @@ module.exports = {
           script.mode !== handler.constants.modes.ACCEPTANCE
         )
       ) {
-        const scriptExtent = impl.scriptExtent(script)
-        const exceedsLimits =
-          scriptExtent.requestsPerSecond > scriptExtent.maxRequestsPerSecond ||
-          scriptExtent.durationInSeconds > scriptExtent.maxDurationInSeconds
-        if (exceedsLimits) { // exceeds limits?
+        const constraints = impl.scriptConstraints(script)
+        if (constraints.allowance < constraints.required) { // exceeds limits?
           process.argv.push('-t')
           process.argv.push('Event')
-          completeMessage = `${os.EOL}\tYour function has been invoked. The load is scheduled to be completed in ${
-            scriptExtent.durationInSeconds} seconds.${os.EOL}`
+          completeMessage = `${os.EOL}\tYour function has been invoked. The load is scheduled to be completed in ${constraints.required} seconds.${os.EOL}`
         }
       }
       // run the given script on the deployed lambda


### PR DESCRIPTION
First, the bleeding had to stop with a fix to get back to parity.

Now we need tests and perhaps a pattern that reduces ongoing bugs.  This PR provides those and fixes #91.

The logic for asking whether we need to use the event type invocation or request-response is simple.  We have an expected allowance, an expected consumption and somewhat conservative tolerances to account for a reasonable amount of unexpected.  This PR makes those assumptions more explicit and takes advantage of this to simplify the code where the results are used.

As per the prior PR, we needed tests to validate this feature.  These are added to a reasonable extent.  We can add more as we discover issues or change the implementation.  The refactor had an impact on the invoke implementation of course.

I twiddled just a bit with other tests to expand to hit otherwise missed defaults.