### PR TITLE
Add `--jo` & `--jsonOnly` to Invoke, Fix console.log use (fix #100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,9 @@ Options:
   -d, --data        A stringified script to execute
   -p, --path        A path to the file containing the script to execute
   --si, --stdIn     Have serverless read the event to invoke the remote function
-                    with from the "standard in" stream.
+                    with from the "standard in" stream
+  --jo, --jsonOnly  Only write JSON to console.log to facilitate piping the
+                    invocation result into a tool such as jq
 
 See https://serverless.com/framework/docs/providers/aws/cli-reference/invoke/ for further supported options.
 

--- a/bin/serverless-artillery
+++ b/bin/serverless-artillery
@@ -59,7 +59,12 @@ const yargs = require('yargs')
       },
       si: {
         alias: 'stdIn',
-        description: 'Have serverless read the event to invoke the remote function with from the "standard in" stream.',
+        description: 'Have serverless read the event to invoke the remote function with from the "standard in" stream',
+        requiresArg: false,
+      },
+      jo: {
+        alias: 'jsonOnly',
+        description: 'Only write JSON to console.log to facilitate piping the invocation result into a tool such as jq',
         requiresArg: false,
       },
     },
@@ -85,7 +90,7 @@ const yargs = require('yargs')
       // TODO while we transition our users away from providing the script via -s/--script, we reject those flags and
       // TODO redirect them.
       if (hasFlag(breakingFlags, argv)) {
-        console.log([
+        console.error([
           os.EOL,
           `DDOS Off!${os.EOL}${os.EOL}`,
           `TL;DR: use -p/--path to supply a script, use --stage to supply a stage.${os.EOL}${os.EOL}`,
@@ -109,7 +114,7 @@ const yargs = require('yargs')
       }
       // ##!! LEGACY MANAGEMENT END   !!##
       if (hasFlag(reservedFlags, argv)) {
-        console.log([
+        console.error([
           os.EOL,
           `!ERROR!${os.EOL}`,
           'One of the `serverless` flags you provided is reserved for exclusive `serverless-artillery` use, ',
@@ -121,7 +126,7 @@ const yargs = require('yargs')
         ].join(''))
         process.exit(1)
       } else if (hasFlag(unsupportedFlags, argv)) {
-        console.log([
+        console.error([
           os.EOL,
           `!ERROR!${os.EOL}`,
           `One of the flags you provided is unsupported by \`serverless-artillery\`.  Unsupported flags include: "${
@@ -188,8 +193,9 @@ if (yargs.debug) {
 
 slsArt[command](yargs)
   .catch((ex) => {
-    console.log(ex.message)
+    console.error(ex.message)
     if (yargs.verbose) {
-      console.log(ex.stack)
+      console.error(ex.stack)
     }
+    process.exit(1)
   })

--- a/lib/index.js
+++ b/lib/index.js
@@ -324,19 +324,15 @@ module.exports = {
           completeMessage = `${os.EOL}\tYour function has been invoked. The load is scheduled to be completed in ${constraints.required} seconds.${os.EOL}`
         }
       }
+      const log = msg => console.log(msg)
+      const logIf = (msg) => { if (!(options.jo || options.jsonOnly)) { log(msg) } }
       // run the given script on the deployed lambda
-      if (!(options.jo || options.jsonOnly)) {
-        console.log(`${os.EOL}\tInvoking test Lambda${os.EOL}`)
-      }
+      logIf(`${os.EOL}\tInvoking test Lambda${os.EOL}`)
       return impl.serverlessRunner(options).then((result) => {
-        if (!(options.jo || options.jsonOnly)) {
-          console.log(completeMessage)
-        }
+        logIf(completeMessage)
         if (options.acceptance) {
-          if (!(options.jo || options.jsonOnly)) {
-            console.log('Results:')
-          }
-          console.log(JSON.stringify(result, null, 2))
+          logIf('Results:')
+          log(JSON.stringify(result, null, 2))
           if (result && result.errors) {
             process.exit(result.errors)
           }

--- a/lib/index.js
+++ b/lib/index.js
@@ -70,7 +70,7 @@ const impl = {
    * @param options The CLI flag settings to identify the input source.
    * @returns {Promise.<string>}
    */
-  getInput: (options) => { // console.log(process.argv); throw new Error('No!');
+  getInput: (options) => {
     // Priority: `--si`, `--stdIn`, `-d`, `--data`, `-p`, `--path`, ./script.yml, $(npm root -g)/script.yml
     if (options.si || options.stdIn) {
       return stdin()
@@ -256,7 +256,7 @@ scenarios:
             try {
               result = JSON.parse(response.Payload)
             } catch (ex) {
-              console.log(`exception parsing payload:${os.EOL
+              console.error(`exception parsing payload:${os.EOL
               }${JSON.stringify(response)}${os.EOL
               }${ex}${os.EOL}${os.EOL
               }Please report this error to this tool's GitHub repo so that we can dig into the cause:${os.EOL
@@ -325,11 +325,17 @@ module.exports = {
         }
       }
       // run the given script on the deployed lambda
-      console.log(`${os.EOL}\tInvoking test Lambda${os.EOL}`)
+      if (!(options.jo || options.jsonOnly)) {
+        console.log(`${os.EOL}\tInvoking test Lambda${os.EOL}`)
+      }
       return impl.serverlessRunner(options).then((result) => {
-        console.log(completeMessage)
+        if (!(options.jo || options.jsonOnly)) {
+          console.log(completeMessage)
+        }
         if (options.acceptance) {
-          console.log('Results:')
+          if (!(options.jo || options.jsonOnly)) {
+            console.log('Results:')
+          }
           console.log(JSON.stringify(result, null, 2))
           if (result && result.errors) {
             process.exit(result.errors)
@@ -339,11 +345,11 @@ module.exports = {
     })
     .catch((ex) => {
       if (ex instanceof func.def.FunctionError) {
-        console.log('Error validating function settings.')
+        console.error('Error validating function settings.')
       } else if (ex instanceof task.def.TaskError) {
-        console.log('Error validating the task settings.')
+        console.error('Error validating the task settings.')
       } else {
-        console.log(`Unexpected Error: ${ex.message}`)
+        console.error(`Unexpected Error: ${ex.message}`)
       }
       process.exit(1)
     }),

--- a/lib/lambda/funcExec.js
+++ b/lib/lambda/funcExec.js
@@ -27,13 +27,13 @@ const impl = {
         try {
           return JSON.parse(res.Payload)
         } catch (ex) {
-          console.log(`Error parsing lambda execution payload:\n${res.Payload}\nCaused error:\n${ex.stack}`)
+          console.error(`Error parsing lambda execution payload:\n${res.Payload}\nCaused error:\n${ex.stack}`)
           return undefined // ignore error
         }
       })
       .catch((ex) => {
-        console.log('Error invoking self:')
-        console.log(ex.stack)
+        console.error('Error invoking self:')
+        console.error(ex.stack)
         return Promise.reject(new Error(`ERROR invoking self: ${ex.message}`))
       })
   },

--- a/lib/lambda/funcHandle.js
+++ b/lib/lambda/funcHandle.js
@@ -2,14 +2,14 @@ const valid = require('./funcValid')
 
 const impl = {
   handleUnhandledRejection: (ex) => {
-    console.log('###############################################################')
-    console.log('##             !! Unhandled promise rejection !!             ##')
-    console.log('## This probably results from an unforseen circumstance in   ##')
-    console.log('## a plugin.  Please report the following stack trace at:    ##')
-    console.log('## https://github.com/Nordstrom/serverless-artillery/issues  ##')
-    console.log('###############################################################')
-    console.log(ex.stack)
-    console.log('###############################################################')
+    console.error('###############################################################')
+    console.error('##             !! Unhandled promise rejection !!             ##')
+    console.error('## This probably results from an unforseen circumstance in   ##')
+    console.error('## a plugin.  Please report the following stack trace at:    ##')
+    console.error('## https://github.com/Nordstrom/serverless-artillery/issues  ##')
+    console.error('###############################################################')
+    console.error(ex.stack)
+    console.error('###############################################################')
     module.exports.callback(
       null,
       `##!! Unhandled promise rejection: ${
@@ -27,11 +27,11 @@ const impl = {
           callback(null, result)
         })
         .catch((ex) => {
-          console.log(ex.stack)
+          console.error(ex.stack)
           callback(null, `Error executing task: ${ex.message}`)
         })
     } catch (ex) {
-      console.log(ex.stack)
+      console.error(ex.stack)
       callback(null, `Error validating event: ${ex.message}`)
     }
   },

--- a/lib/lambda/handler.js
+++ b/lib/lambda/handler.js
@@ -10,7 +10,6 @@ const impl = {
    * @returns {Promise<any>}
    */
   delay: (ms) => {
-    console.log(`delay ms: ${ms}`)
     if (ms > 0) {
       return new Promise(resolve => setTimeout(resolve, ms))
     } else {
@@ -105,8 +104,8 @@ const impl = {
           })
       })
       .catch((ex) => {
-        console.log(`error executing load script from ${script._genesis} in ${timeNow} @ ${Date.now()}:`)
-        console.log(ex.stack)
+        console.error(`error executing load script from ${script._genesis} in ${timeNow} @ ${Date.now()}:`)
+        console.error(ex.stack)
         throw ex
       })
   },
@@ -131,7 +130,7 @@ const impl = {
       return impl.execute(timeNow, plans[0], settings)
     } else {
       const msg = `ERROR, no executable content in:\n${JSON.stringify(script)}!`
-      console.log(msg)
+      console.error(msg)
       return Promise.reject(new Error(msg))
     }
   },

--- a/lib/lambda/taskExec.js
+++ b/lib/lambda/taskExec.js
@@ -44,7 +44,7 @@ const impl = {
         // Just load the one playload
         ret = readSinglePayload(script.config.payload)
       } else {
-        console.log('WARNING: payload file not set, but payload is configured.\n')
+        console.warn('WARNING: payload file not set, but payload is configured.\n')
       }
     }
     return ret
@@ -92,7 +92,7 @@ const impl = {
           runner.run()
         } catch (ex) {
           msg = `ERROR exception encountered while executing load from ${script._genesis} in ${timeNow}: ${ex.message}\n${ex.stack}`
-          console.log(msg)
+          console.error(msg)
           reject(new def.TaskError(msg))
         }
       })

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "slsart": "./bin/serverless-artillery"
   },
   "scripts": {
-    "test": "./node_modules/.bin/nyc ./node_modules/.bin/_mocha -r aws-sdk -r ./lib/lambda/node_modules/artillery-core --recursive tests",
+    "test": "./node_modules/.bin/nyc ./node_modules/.bin/_mocha -r aws-sdk -r ./lib/lambda/node_modules/artillery-core \"./tests/**/*.spec.js\"",
+    "light": "./node_modules/.bin/nyc ./node_modules/.bin/_mocha -r aws-sdk -r ./lib/lambda/node_modules/artillery-core \"./tests/**/!(serverless-artillery|npm).spec.js\"",
     "coverage": "./node_modules/.bin/nyc report --reporter=text-lcov | coveralls",
     "lint": "./node_modules/.bin/eslint . bin/serverless-artillery",
     "postinstall": "node ./postinstall.js",

--- a/tests/lib/index.spec.js
+++ b/tests/lib/index.spec.js
@@ -640,6 +640,29 @@ scenarios:
             } // eslint-disable-line comma-dangle
           ) // eslint-disable-line comma-dangle
         )
+        const result = { msg: 'a result' }
+        it('writes only the JSON result of the invocation to the console.log stream',
+          replaceImpl(
+            { allowance: 2, required: 1 },
+            result,
+            () => slsart.invoke({ jo: true, acceptance: true, d: testJsonScriptStringified })
+              .then(() => {
+                expect(logs.length).to.be.equal(1)
+                expect(logs[0]).to.equal(JSON.stringify(result, null, 2))
+              }) // eslint-disable-line comma-dangle
+          ) // eslint-disable-line comma-dangle
+        )
+        it('writes only the JSON result of the invocation to the console.log stream',
+          replaceImpl(
+            { allowance: 2, required: 1 },
+            result,
+            () => slsart.invoke({ jsonOnly: true, acceptance: true, d: testJsonScriptStringified })
+              .then(() => {
+                expect(logs.length).to.be.equal(1)
+                expect(logs[0]).to.equal(JSON.stringify(result, null, 2))
+              }) // eslint-disable-line comma-dangle
+          ) // eslint-disable-line comma-dangle
+        )
       })
     })
 

--- a/tests/lib/lambda/funcHandle.spec.js
+++ b/tests/lib/lambda/funcHandle.spec.js
@@ -14,15 +14,15 @@ describe('./lib/lambda/funcHandle.js', () => {
   describe(':impl', () => {
     describe('#handleUnhandledRejection', () => {
       it('prints to the console and calls the callback', () => {
-        const consoleLog = console.log
+        const consoleLog = console.error
         let logCalled = false
-        console.log = () => { logCalled = true }
+        console.error = () => { logCalled = true }
         let callbackCalled = false
         func.handle.callback = () => { callbackCalled = true }
         func.handle.impl.handleUnhandledRejection(new Error('tag'))
         expect(logCalled).to.be.true
         expect(callbackCalled).to.be.true
-        console.log = consoleLog
+        console.error = consoleLog
       })
     })
     describe('#handler', () => {

--- a/tests/lib/lambda/handler.spec.js
+++ b/tests/lib/lambda/handler.spec.js
@@ -166,12 +166,12 @@ describe('./lib/lambda/handler.js', () => {
           .then(() => expect(script._start).to.equal(timeNow)) // eslint-disable-line no-underscore-dangle
       })
       describe('error logging', () => {
-        let consoleLogStub
+        let consoleErrorStub
         beforeEach(() => {
-          consoleLogStub = sinon.stub(console, 'log').returns()
+          consoleErrorStub = sinon.stub(console, 'error').returns()
         })
         afterEach(() => {
-          consoleLogStub.restore()
+          consoleErrorStub.restore()
         })
         it('logs and throws errors that are throw up the promise chain by impl.deploy', () => {
           implDelayStub.throws(new Error('impl.deploy'))
@@ -181,31 +181,31 @@ describe('./lib/lambda/handler.js', () => {
           implDelayStub.returns(Promise.reject(new Error('impl.deploy')))
           return expect(handler.impl.execute(Date.now(), {}, defaultSettings))
             .to.eventually.be.rejected
-            .then(() => expect(consoleLogStub).to.have.been.called)
+            .then(() => expect(consoleErrorStub).to.have.been.called)
         })
         it('logs and throws errors that are throw up the promise chain by task.exec', () => {
           taskExecStub.throws(new Error('task.exec'))
           return expect(handler.impl.execute(Date.now(), {}, defaultSettings))
             .to.eventually.be.rejected
-            .then(() => expect(consoleLogStub).to.have.been.called)
+            .then(() => expect(consoleErrorStub).to.have.been.called)
         })
         it('logs and throws errors resulting from a rejection by task.exec', () => {
           taskExecStub.returns(Promise.reject(new Error('task.exec')))
           return expect(handler.impl.execute(Date.now(), {}, defaultSettings))
             .to.eventually.be.rejected
-            .then(() => expect(consoleLogStub).to.have.been.called)
+            .then(() => expect(consoleErrorStub).to.have.been.called)
         })
         it('logs and throws errors that are throw up the promise chain by task.result', () => {
           taskResultStub.throws(new Error('task.result'))
           return expect(handler.impl.execute(Date.now(), {}, defaultSettings))
             .to.eventually.be.rejected
-            .then(() => expect(consoleLogStub).to.have.been.called)
+            .then(() => expect(consoleErrorStub).to.have.been.called)
         })
         it('logs and throws errors resulting from a rejection by task.result', () => {
           taskResultStub.returns(Promise.reject(new Error('task.result')))
           return expect(handler.impl.execute(Date.now(), {}, defaultSettings))
             .to.eventually.be.rejected
-            .then(() => expect(consoleLogStub).to.have.been.called)
+            .then(() => expect(consoleErrorStub).to.have.been.called)
         })
       })
     })


### PR DESCRIPTION
This PR assumes that #103 is merged prior.

Add the flags `--jo` and `--jsonOnly` to the invoke command that have the effect of suppressing all console output except for the JSON payload returned by the remote function.  This enables the piping of output to tools such as jq.

Use `log`, `warn`, and `error` as appropriate instead of just `log`
Clean up unintended logging and a commented out bit of logging that was for testing

Between these two changes, this commit fixes #100

For convenience, add a "light" script to the package.json that runs all tests excluding the long serverless-artillery.spec.js and npm.spec.js tests