### PR TITLE
Setting min script chunk time to 15 seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,8 +311,7 @@ The following controls are available in the default deployed function.  That sai
 {
   _split: {
     maxScriptDurationInSeconds: 86400,  # Default listed.  Hard-coded max is 518400
-    maxChunkDurationInSeconds: 240,     # Default listed.  Hard-coded max is 285
-                                                           Hard-coded min is 15
+    maxChunkDurationInSeconds: 240,     # Default listed.  Hard-coded max is 285, min is 15
     maxScriptRequestsPerSecond: 5000,   # Default listed.  Hard-coded max is 50000
     maxChunkRequestsPerSecond: 25,      # Default listed.  Hard-coded max is 500
     timeBufferInMilliseconds: 15000,    # Default listed.  Hard-coded max is 30000

--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ The following controls are available in the default deployed function.  That sai
   _split: {
     maxScriptDurationInSeconds: 86400,  # Default listed.  Hard-coded max is 518400
     maxChunkDurationInSeconds: 240,     # Default listed.  Hard-coded max is 285
+                                                           Hard-coded min is 15
     maxScriptRequestsPerSecond: 5000,   # Default listed.  Hard-coded max is 50000
     maxChunkRequestsPerSecond: 25,      # Default listed.  Hard-coded max is 500
     timeBufferInMilliseconds: 15000,    # Default listed.  Hard-coded max is 30000

--- a/lib/lambda/funcDef.js
+++ b/lib/lambda/funcDef.js
@@ -26,6 +26,10 @@ const constants = {
    */
   MAX_CHUNK_DURATION_IN_SECONDS: 285, // 4 minutes and 45 seconds (allow for 15 second alignment time)
   /**
+   * The hard coded minimum duration for a single lambda to execute in seconds.
+   */
+  MIN_CHUNK_DURATION_IN_SECONDS: 15, // 15 seconds
+  /**
    * The default maximum duration for a scenario in seconds (this is how much time a script is allowed to take before
    * it will be split across multiple function executions)
    */

--- a/lib/lambda/funcValid.js
+++ b/lib/lambda/funcValid.js
@@ -15,12 +15,12 @@ const impl = {
         'maxChunkDurationInSeconds' in settings &&
         (
           !Number.isInteger(settings.maxChunkDurationInSeconds) ||
-          settings.maxChunkDurationInSeconds <= 0 ||
+          settings.maxChunkDurationInSeconds < def.MIN_CHUNK_DURATION_IN_SECONDS ||
           settings.maxChunkDurationInSeconds > def.MAX_CHUNK_DURATION_IN_SECONDS
         )
       ) {
         throw new def.FunctionError('If specified the "_split.maxChunkDurationInSeconds" attribute must be an integer ' +
-          `inclusively between 1 and ${def.MAX_CHUNK_DURATION_IN_SECONDS}.`)
+          `inclusively between ${def.MIN_CHUNK_DURATION_IN_SECONDS} and ${def.MAX_CHUNK_DURATION_IN_SECONDS}.`)
       } else if (
         'maxScriptDurationInSeconds' in settings &&
         (

--- a/tests/lib/lambda/funcValid.spec.js
+++ b/tests/lib/lambda/funcValid.spec.js
@@ -43,7 +43,7 @@ describe('./lib/lambda/funcValid.js', () => {
           expect(() => func.valid(script)).to.throw(func.def.FunctionError)
         })
         const settings = [
-          { name: 'maxChunkDurationInSeconds', max: func.def.MAX_CHUNK_DURATION_IN_SECONDS },
+          { name: 'maxChunkDurationInSeconds', max: func.def.MAX_CHUNK_DURATION_IN_SECONDS, min: func.def.MIN_CHUNK_DURATION_IN_SECONDS },
           { name: 'maxScriptDurationInSeconds', max: func.def.MAX_SCRIPT_DURATION_IN_SECONDS },
           { name: 'maxChunkRequestsPerSecond', max: func.def.MAX_CHUNK_REQUESTS_PER_SECOND },
           { name: 'maxScriptRequestsPerSecond', max: func.def.MAX_SCRIPT_REQUESTS_PER_SECOND },
@@ -55,9 +55,13 @@ describe('./lib/lambda/funcValid.js', () => {
               script._split[setting.name] = 'not a number'
               expect(() => func.valid(script)).to.throw(func.def.FunctionError)
             })
-            it('rejects negative values', () => {
+            it('rejects negative & hard-coded minimum values', () => {
               script._split[setting.name] = -1
               expect(() => func.valid(script)).to.throw(func.def.FunctionError)
+              if (setting.name === 'maxChunkDurationInSeconds') {
+                script._split[setting.name] = setting.min - 1
+                expect(() => func.valid(script)).to.throw(func.def.FunctionError)
+              }
             })
             it(`rejects values greater than ${setting.max}`, () => {
               script._split[setting.name] = setting.max + 1

--- a/tests/lib/lambda/funcValid.spec.js
+++ b/tests/lib/lambda/funcValid.spec.js
@@ -55,18 +55,20 @@ describe('./lib/lambda/funcValid.js', () => {
               script._split[setting.name] = 'not a number'
               expect(() => func.valid(script)).to.throw(func.def.FunctionError)
             })
-            it('rejects negative & hard-coded minimum values', () => {
+            it('rejects negative values', () => {
               script._split[setting.name] = -1
               expect(() => func.valid(script)).to.throw(func.def.FunctionError)
-              if (setting.name === 'maxChunkDurationInSeconds') {
-                script._split[setting.name] = setting.min - 1
-                expect(() => func.valid(script)).to.throw(func.def.FunctionError)
-              }
             })
             it(`rejects values greater than ${setting.max}`, () => {
               script._split[setting.name] = setting.max + 1
               expect(() => func.valid(script)).to.throw(func.def.FunctionError)
             })
+            if (setting.min) {
+              it(`rejects values less than ${setting.min}`, () => {
+                script._split[setting.name] = setting.min - 1
+                expect(() => func.valid(script)).to.throw(func.def.FunctionError)
+              })
+            }
           })
         })
       })


### PR DESCRIPTION
Currently, chunks of scripts can run up to 4 minutes, but there is no hard minimum duration. These changes now require that the minimum be at least 15 seconds.