### PR TITLE
add function name metadata to the event

### DIFF
--- a/lib/lambda/funcExec.js
+++ b/lib/lambda/funcExec.js
@@ -1,6 +1,5 @@
 const aws = require('aws-sdk') // eslint-disable-line import/no-extraneous-dependencies
 
-const handle = require('./funcHandle')
 const valid = require('./funcValid')
 
 const lambda = new aws.Lambda({ maxRetries: 0 })
@@ -15,7 +14,7 @@ const impl = {
   execute: (event, type) => {
     valid(event)
     const params = {
-      FunctionName: handle.context.functionName,
+      FunctionName: event._functionName, // eslint-disable-line no-underscore-dangle
       InvocationType: type || 'Event',
       Payload: JSON.stringify(event),
     }

--- a/lib/lambda/funcHandle.js
+++ b/lib/lambda/funcHandle.js
@@ -112,8 +112,20 @@ const impl = {
     }
   },
 
+  addMetadataToInput: (input, context) =>
+    Object.assign(
+      {},
+      input,
+      { _functionName: context.functionName }
+    ),
+
   createHandler: (
-    { createUnhandledRejectionHandler, handleTimeout, mergeAndInvoke } = impl,
+    {
+      createUnhandledRejectionHandler,
+      handleTimeout,
+      mergeAndInvoke,
+      addMetadataToInput,
+    } = impl,
     timeoutMs = maxTimeoutBuffer
   ) =>
     taskHandler =>
@@ -126,7 +138,7 @@ const impl = {
           () => handleTimeout(finished),
           context.getRemainingTimeInMillis() - timeoutMs
         )
-        mergeAndInvoke(taskHandler, input)
+        mergeAndInvoke(taskHandler, addMetadataToInput(input, context))
           .catch(ex => `Error executing handler: ${ex.message}`)
           .then((result) => {
             process.removeListener('unhandledRejection', onUnhandledRejection)

--- a/tests/lib/lambda/funcExec.spec.js
+++ b/tests/lib/lambda/funcExec.spec.js
@@ -20,6 +20,7 @@ const tagContext = {
 }
 
 const validScript = () => ({
+  _functionName: tagContext.functionName,
   config: {
     phases: [
       {
@@ -38,24 +39,13 @@ describe('./lib/lambda/funcExec.js', () => {
     awsStub.restore()
   })
   describe(':impl', () => {
-    let contextInHandler = 'context' in func.handle
-    let handlerContext = func.handle.context
     beforeEach(() => {
-      // function context
-      contextInHandler = 'context' in func.handle
-      handlerContext = func.handle.context
-      func.handle.context = tagContext
       // lambda invocation stubbing
       awsStub.withArgs('invoke', sinon.match.any, sinon.match.any).callsFake(
         () => ({ promise: () => Promise.resolve({ Payload: '{}' }) }) // eslint-disable-line comma-dangle
       )
     })
     afterEach(() => {
-      if (contextInHandler) {
-        func.handle.context = handlerContext
-      } else {
-        delete func.handle.context
-      }
       awsStub.reset()
     })
     describe('#execute', () => {


### PR DESCRIPTION
This PR fixes a latent side-effect in the `execute` function in `lib/lambda/funcExec.js`. The prior logic consumed a mutable field of `lib/lambda/funcHandle.js`. The new logic eliminates the side-effect by attaching the field to the `event` parameter so that all required data is passed into the `execute` method. Tests have been updated to match.