### PR TITLE
Switch from top level to private hive

### DIFF
--- a/lib/lambda/funcExec.js
+++ b/lib/lambda/funcExec.js
@@ -14,7 +14,7 @@ const impl = {
   execute: (event, type) => {
     valid(event)
     const params = {
-      FunctionName: event._functionName, // eslint-disable-line no-underscore-dangle
+      FunctionName: event._funcAws.functionName, // eslint-disable-line no-underscore-dangle
       InvocationType: type || 'Event',
       Payload: JSON.stringify(event),
     }

--- a/lib/lambda/funcHandle.js
+++ b/lib/lambda/funcHandle.js
@@ -112,11 +112,13 @@ const impl = {
     }
   },
 
-  addMetadataToInput: (input, context) =>
+  addMetadataToInput: (input, { functionName }) =>
     Object.assign(
       {},
       input,
-      { _functionName: context.functionName }
+      {
+        _funcAws: { functionName },
+      }
     ),
 
   createHandler: (

--- a/tests/lib/lambda/funcExec.spec.js
+++ b/tests/lib/lambda/funcExec.spec.js
@@ -20,7 +20,9 @@ const tagContext = {
 }
 
 const validScript = () => ({
-  _functionName: tagContext.functionName,
+  _funcAws: {
+    functionName: tagContext.functionName,
+  },
   config: {
     phases: [
       {

--- a/tests/lib/lambda/funcHandle.spec.js
+++ b/tests/lib/lambda/funcHandle.spec.js
@@ -51,7 +51,7 @@ describe('./lib/lambda/funcHandle.js', () => {
         const context = { functionName: 'baz' }
         const output = addMetadataToInput(input, context)
         assert.notStrictEqual(input, output)
-        assert.deepStrictEqual(output, { foo: 'bar', _functionName: 'baz' })
+        assert.deepStrictEqual(output, { foo: 'bar', _funcAws: { functionName: 'baz' } })
       })
     })
     describe('#createHandler', () => {
@@ -144,7 +144,7 @@ describe('./lib/lambda/funcHandle.js', () => {
       it('should add metadata to input', () => {
         const { createUnhandledRejectionHandler, handleTimeout } = func.handle.impl
         const answer = {}
-        const inputWithMetadata = { _functionName: 'foo' }
+        const inputWithMetadata = { _funcAws: { functionName: 'foo' } }
         const mergeAndInvoke = sinon.stub().returns(Promise.resolve(answer))
         const context = { getRemainingTimeInMillis: () => 60000 }
         const addMetadataToInput = sinon.stub().callsFake(() => inputWithMetadata)


### PR DESCRIPTION
The functionName attribute represents private inside-baseball information.  As a result, storing it at the top level of the event seems inappropraite.  This commit and its changes propose that such settings should be stored within plugin specific hives inside of which a plugin can do whatever it likes for its own consumption.  Data stored in such a location makes no guarantees to anyone about its continued existence and should not be depended upon by any other code.