### PR TITLE
Per #173 we've broken the contract from any SA consumers by providing…

### DIFF
--- a/lib/lambda/taskExec.js
+++ b/lib/lambda/taskExec.js
@@ -31,7 +31,7 @@ module.exports = run =>
       }
 
       console.log('Starting Artillery...')
-      run(script, { output: (result) => { testResults = result } })
+      run(script, { output: (result) => { testResults = result.aggregate } })
     })
       .catch((ex) => {
         const msg = `ERROR exception encountered while executing load from ${script._genesis} in ${timeNow}: ${ex.message}\n${ex.stack}`

--- a/tests/lib/lambda/taskExec.spec.js
+++ b/tests/lib/lambda/taskExec.spec.js
@@ -36,9 +36,10 @@ describe('./lib/lambda/taskExec.js', () => {
 
     it('invokes artillery:run and returns the results', () => {
       script = { _trace: true, _simulation: false }
+      const artilleryResults = { aggregate: { Payload: '{ "errors": 0 }' } }
       results = { Payload: '{ "errors": 0 }' }
 
-      return taskExec(runnerMock(script, results, 0))(1, script)
+      return taskExec(runnerMock(script, artilleryResults, 0))(1, script)
         .should.eventually.eql(results)
     })
 


### PR DESCRIPTION
… results in a different layout than before; this change is intended to restore the previous by retaining only the `aggregate` property when output is called with results.