### PR TITLE
Add function assets check when invoking for monitoring mode to prevent issue #161.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -508,10 +508,19 @@ scenarios:
         }
       })
   },
+  /**
+   * Check the version of the local function assets version, the invocation options
+   * and script mode and if the invocation type is monitoring and the default
+   * version is found, then an error is thrown to prevent the user from invoking
+   * a function that is incompatible with monitoring mode.
+   * @param options The SA invocation options
+   * @param script Artillery script being run
+   * @param cwd Function to get the current working directory path
+   */
   validateServiceForInvocation: (options, script, cwd = process.cwd) => {
     let toss = false
     try {
-      const localService = require(path.join(cwd(), 'package.json')) // eslint-disable-line global-require import/no-dynamic-require
+      const localService = require(path.join(cwd(), 'package.json')) // eslint-disable-line global-require, import/no-dynamic-require
       toss = !('version' in localService) &&
         (
           options.monitoring ||
@@ -525,10 +534,10 @@ scenarios:
       throw new Error([
         '',
         `Your local function project assets in ${cwd()} implements a service`,
-        `version that does not support invocation with the monitoring flag.`,
+        'version that does not support invocation with the monitoring flag.',
         '',
-        `To use monitoring mode, please run the "configure" command`,
-        `in a clean directory and then customize your worker's assets.`,
+        'To use monitoring mode, please run the "configure" command',
+        'in a clean directory and then customize your worker\'s assets.',
       ].join(`${os.EOL}\t`))
     }
   },
@@ -651,64 +660,59 @@ module.exports = {
    * @return {Promise.<TResult>} A promise that completes after the invocation of the function with the script given
    * by the user (or a fallback option).
    */
-  invoke: options => {
-    try {
-      impl.validateServiceForInvocation()
-    } catch (validationEx) {
-      return Promise.reject(validationEx)
-    }
-    return impl.getInput(options)
-      .then(impl.parseInput)
-      .then((input) => {
-        const script = input
-        if (options.acceptance) {
-          script.mode = task.def.modes.ACC
-        } else if (options.monitoring) {
-          script.mode = task.def.modes.MON
+  invoke: options => impl.getInput(options)
+    .then(impl.parseInput)
+    .then((input) => {
+      const script = input
+      if (options.acceptance) {
+        script.mode = task.def.modes.ACC
+      } else if (options.monitoring) {
+        script.mode = task.def.modes.MON
+      }
+      impl.replaceArgv(script)
+      // check local assets version
+      impl.validateServiceForInvocation(options, script)
+      // analyze script if tool or script is in performance mode
+      let completeMessage = `${os.EOL}\tYour function invocation has completed.${os.EOL}`
+      if (!task.def.isSamplingScript(script)) {
+        const constraints = impl.scriptConstraints(script)
+        if (constraints.allowance < constraints.required) { // exceeds limits?
+          process.argv.push('-t')
+          process.argv.push('Event')
+          completeMessage = `${os.EOL}\tYour function has been invoked. The load is scheduled to be completed in ${constraints.required} seconds.${os.EOL}`
         }
-        impl.replaceArgv(script)
-        // analyze script if tool or script is in performance mode
-        let completeMessage = `${os.EOL}\tYour function invocation has completed.${os.EOL}`
-        if (!task.def.isSamplingScript(script)) {
-          const constraints = impl.scriptConstraints(script)
-          if (constraints.allowance < constraints.required) { // exceeds limits?
-            process.argv.push('-t')
-            process.argv.push('Event')
-            completeMessage = `${os.EOL}\tYour function has been invoked. The load is scheduled to be completed in ${constraints.required} seconds.${os.EOL}`
+      }
+      const log = msg => console.log(msg)
+      const logIf = (msg) => {
+        if (!(options.jo || options.jsonOnly)) {
+          log(msg)
+        }
+      }
+      // run the given script on the deployed lambda
+      logIf(`${os.EOL}\tInvoking test Lambda${os.EOL}`)
+      return impl.serverlessRunner(options).then((result) => {
+        logIf(completeMessage)
+        if (options.acceptance || options.monitoring) {
+          logIf('Results:')
+          log(JSON.stringify(result, null, 2))
+          if (result && result.errors) {
+            console.error(`Errors exceeding errorBudget observed in ${result.errors} sample(s).`)
+            process.exit(result.errors)
           }
         }
-        const log = msg => console.log(msg)
-        const logIf = (msg) => {
-          if (!(options.jo || options.jsonOnly)) {
-            log(msg)
-          }
-        }
-        // run the given script on the deployed lambda
-        logIf(`${os.EOL}\tInvoking test Lambda${os.EOL}`)
-        return impl.serverlessRunner(options).then((result) => {
-          logIf(completeMessage)
-          if (options.acceptance || options.monitoring) {
-            logIf('Results:')
-            log(JSON.stringify(result, null, 2))
-            if (result && result.errors) {
-              console.error(`Errors exceeding errorBudget observed in ${result.errors} sample(s).`)
-              process.exit(result.errors)
-            }
-          }
-          return result
-        })
+        return result
       })
-      .catch((ex) => {
-        if (ex instanceof func.def.FunctionError) {
-          console.error('Error validating function settings:')
-        } else if (ex instanceof task.def.TaskError) {
-          console.error('Error validating the task settings:')
-        } else {
-          console.error('Unexpected Error:')
-        }
-        throw ex
-      })
-  },
+    })
+    .catch((ex) => {
+      if (ex instanceof func.def.FunctionError) {
+        console.error('Error validating function settings:')
+      } else if (ex instanceof task.def.TaskError) {
+        console.error('Error validating the task settings:')
+      } else {
+        console.error('Unexpected Error:')
+      }
+      throw ex
+    }),
   /**
    * Kill an invoked lambda that is actively executing.
    */

--- a/lib/index.js
+++ b/lib/index.js
@@ -683,11 +683,7 @@ module.exports = {
         }
       }
       const log = msg => console.log(msg)
-      const logIf = (msg) => {
-        if (!(options.jo || options.jsonOnly)) {
-          log(msg)
-        }
-      }
+      const logIf = (msg) => { if (!(options.jo || options.jsonOnly)) { log(msg) } }
       // run the given script on the deployed lambda
       logIf(`${os.EOL}\tInvoking test Lambda${os.EOL}`)
       return impl.serverlessRunner(options).then((result) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -508,6 +508,30 @@ scenarios:
         }
       })
   },
+  validateServiceForInvocation: (options, script, cwd = process.cwd) => {
+    let toss = false
+    try {
+      const localService = require(path.join(cwd(), 'package.json')) // eslint-disable-line global-require import/no-dynamic-require
+      toss = !('version' in localService) &&
+        (
+          options.monitoring ||
+          script.mode === task.def.modes.MON ||
+          script.mode === task.def.modes.MONITORING
+        )
+    } catch (ex) {
+      // can't be found.  that's okay, we could be using the default service
+    }
+    if (toss) {
+      throw new Error([
+        '',
+        `Your local function project assets in ${cwd()} implements a service`,
+        `version that does not support invocation with the monitoring flag.`,
+        '',
+        `To use monitoring mode, please run the "configure" command`,
+        `in a clean directory and then customize your worker's assets.`,
+      ].join(`${os.EOL}\t`))
+    }
+  },
   // SERVERLESS UTILS
   /**
    * Checks working directory for service config, otherwise uses default.
@@ -627,53 +651,64 @@ module.exports = {
    * @return {Promise.<TResult>} A promise that completes after the invocation of the function with the script given
    * by the user (or a fallback option).
    */
-  invoke: options => impl.getInput(options)
-    .then(impl.parseInput)
-    .then((input) => {
-      const script = input
-      if (options.acceptance) {
-        script.mode = task.def.modes.ACC
-      } else if (options.monitoring) {
-        script.mode = task.def.modes.MON
-      }
-      impl.replaceArgv(script)
-      // analyze script if tool or script is in performance mode
-      let completeMessage = `${os.EOL}\tYour function invocation has completed.${os.EOL}`
-      if (!task.def.isSamplingScript(script)) {
-        const constraints = impl.scriptConstraints(script)
-        if (constraints.allowance < constraints.required) { // exceeds limits?
-          process.argv.push('-t')
-          process.argv.push('Event')
-          completeMessage = `${os.EOL}\tYour function has been invoked. The load is scheduled to be completed in ${constraints.required} seconds.${os.EOL}`
+  invoke: options => {
+    try {
+      impl.validateServiceForInvocation()
+    } catch (validationEx) {
+      return Promise.reject(validationEx)
+    }
+    return impl.getInput(options)
+      .then(impl.parseInput)
+      .then((input) => {
+        const script = input
+        if (options.acceptance) {
+          script.mode = task.def.modes.ACC
+        } else if (options.monitoring) {
+          script.mode = task.def.modes.MON
         }
-      }
-      const log = msg => console.log(msg)
-      const logIf = (msg) => { if (!(options.jo || options.jsonOnly)) { log(msg) } }
-      // run the given script on the deployed lambda
-      logIf(`${os.EOL}\tInvoking test Lambda${os.EOL}`)
-      return impl.serverlessRunner(options).then((result) => {
-        logIf(completeMessage)
-        if (options.acceptance || options.monitoring) {
-          logIf('Results:')
-          log(JSON.stringify(result, null, 2))
-          if (result && result.errors) {
-            console.error(`Errors exceeding errorBudget observed in ${result.errors} sample(s).`)
-            process.exit(result.errors)
+        impl.replaceArgv(script)
+        // analyze script if tool or script is in performance mode
+        let completeMessage = `${os.EOL}\tYour function invocation has completed.${os.EOL}`
+        if (!task.def.isSamplingScript(script)) {
+          const constraints = impl.scriptConstraints(script)
+          if (constraints.allowance < constraints.required) { // exceeds limits?
+            process.argv.push('-t')
+            process.argv.push('Event')
+            completeMessage = `${os.EOL}\tYour function has been invoked. The load is scheduled to be completed in ${constraints.required} seconds.${os.EOL}`
           }
         }
-        return result
+        const log = msg => console.log(msg)
+        const logIf = (msg) => {
+          if (!(options.jo || options.jsonOnly)) {
+            log(msg)
+          }
+        }
+        // run the given script on the deployed lambda
+        logIf(`${os.EOL}\tInvoking test Lambda${os.EOL}`)
+        return impl.serverlessRunner(options).then((result) => {
+          logIf(completeMessage)
+          if (options.acceptance || options.monitoring) {
+            logIf('Results:')
+            log(JSON.stringify(result, null, 2))
+            if (result && result.errors) {
+              console.error(`Errors exceeding errorBudget observed in ${result.errors} sample(s).`)
+              process.exit(result.errors)
+            }
+          }
+          return result
+        })
       })
-    })
-    .catch((ex) => {
-      if (ex instanceof func.def.FunctionError) {
-        console.error('Error validating function settings:')
-      } else if (ex instanceof task.def.TaskError) {
-        console.error('Error validating the task settings:')
-      } else {
-        console.error('Unexpected Error:')
-      }
-      throw ex
-    }),
+      .catch((ex) => {
+        if (ex instanceof func.def.FunctionError) {
+          console.error('Error validating function settings:')
+        } else if (ex instanceof task.def.TaskError) {
+          console.error('Error validating the task settings:')
+        } else {
+          console.error('Unexpected Error:')
+        }
+        throw ex
+      })
+  },
   /**
    * Kill an invoked lambda that is actively executing.
    */

--- a/lib/index.js
+++ b/lib/index.js
@@ -511,9 +511,8 @@ scenarios:
   /**
    * Check the version of the local function assets version, the invocation options
    * and script mode and if the invocation type is monitoring and the default
-   * version is found, then an error is thrown to prevent the user from invoking
-   * a function that is incompatible with monitoring mode.
-   * @param options The SA invocation options
+   * version is found, then an error is thrown.
+   * @param options The invoke command line options
    * @param script Artillery script being run
    * @param cwd Function to get the current working directory path
    */

--- a/lib/lambda/package.json
+++ b/lib/lambda/package.json
@@ -1,4 +1,5 @@
 {
+  "version": "0.0.1",
   "description": "A load generator function implementation",
   "repository": "n/a",
   "license": "Apache-2.0",

--- a/tests/lib/func-assets-default/package.json
+++ b/tests/lib/func-assets-default/package.json
@@ -1,0 +1,12 @@
+{
+  "description": "A load generator function implementation",
+  "repository": "n/a",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "artillery": "git+https://github.com/Nordstrom/artillery.git#2d99b7ab1075e9df9f6eb2903102abc7849f1879",
+    "js-yaml": "^3.11.0",
+    "lodash.merge": "^4.6.1",
+    "lodash.omit": "^4.5.0",
+    "util-promisify": "^2.1.0"
+  }
+}

--- a/tests/lib/func-assets-v0-0-1/package.json
+++ b/tests/lib/func-assets-v0-0-1/package.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.0.1",
+  "description": "A load generator function implementation",
+  "repository": "n/a",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "artillery": "git+https://github.com/Nordstrom/artillery.git#2d99b7ab1075e9df9f6eb2903102abc7849f1879",
+    "js-yaml": "^3.11.0",
+    "lodash.merge": "^4.6.1",
+    "lodash.omit": "^4.5.0",
+    "util-promisify": "^2.1.0"
+  }
+}

--- a/tests/lib/index.spec.js
+++ b/tests/lib/index.spec.js
@@ -690,6 +690,56 @@ scenarios:
       })
     })
 
+    describe('#validateServiceForInvocation', () => {
+      const defaultAssetsCwd = () => path.join(__dirname, 'func-assets-default')
+      const v0_0_1_AssetsCwd = () => path.join(__dirname, 'func-assets-v0-0-1') // eslint-disable-line camelcase
+
+      describe('default function asset versions', () => {
+        it('rejects if invocation options include monitoring', () => {
+          expect(() =>
+            slsart.impl.validateServiceForInvocation({ monitoring: true }, {}, defaultAssetsCwd)
+          ).to.throw(/does not support invocation with the monitoring flag/)
+        })
+        it('rejects if script mode is "mon"', () => {
+          expect(() =>
+            slsart.impl.validateServiceForInvocation({}, { mode: task.def.modes.MON }, defaultAssetsCwd)
+          ).to.throw(/does not support invocation with the monitoring flag/)
+        })
+        it('rejects if script mode is "monitoring"', () => {
+          expect(() =>
+            slsart.impl.validateServiceForInvocation({}, { mode: task.def.modes.MONITORING }, defaultAssetsCwd)
+          ).to.throw(/does not support invocation with the monitoring flag/)
+        })
+        it('does not reject default version otherwise', () => {
+          expect(() =>
+            slsart.impl.validateServiceForInvocation({}, {}, defaultAssetsCwd)
+          ).not.to.throw()
+        })
+      })
+      describe('v 0.0.1 function asset versions', () => {
+        it('does not reject if invocation options include monitoring', () => {
+          expect(() =>
+            slsart.impl.validateServiceForInvocation({ monitoring: true }, {}, v0_0_1_AssetsCwd)
+          ).not.to.throw(/does not support invocation with the monitoring flag/)
+        })
+        it('does not reject if script mode is "mon"', () => {
+          expect(() =>
+            slsart.impl.validateServiceForInvocation({}, { mode: task.def.modes.MON }, v0_0_1_AssetsCwd)
+          ).not.to.throw(/does not support invocation with the monitoring flag/)
+        })
+        it('does not reject if script mode is "monitoring"', () => {
+          expect(() =>
+            slsart.impl.validateServiceForInvocation({}, { mode: task.def.modes.MONITORING }, v0_0_1_AssetsCwd)
+          ).not.to.throw(/does not support invocation with the monitoring flag/)
+        })
+        it('does not reject default version otherwise', () => {
+          expect(() =>
+            slsart.impl.validateServiceForInvocation({}, {}, v0_0_1_AssetsCwd)
+          ).not.to.throw()
+        })
+      })
+    })
+
     describe('#findServicePath', () => {
       const lambdaPath = path.resolve('lib', 'lambda')
       const replaceImpl = (cwdResult, fileExistsResult, testFunc) => (() => {

--- a/tests/lib/index.spec.js
+++ b/tests/lib/index.spec.js
@@ -817,6 +817,7 @@ scenarios:
 
       let log
       let logs
+      let validateServiceForInvocationStub
       beforeEach(() => {
         ({ log } = console)
         logs = []
@@ -827,10 +828,12 @@ scenarios:
             logs.push(args.join(' '))
           }
         }
+        validateServiceForInvocationStub = sinon.stub(slsart.impl, 'validateServiceForInvocation').returns()
       })
       afterEach(() => {
         console.log = log
         process.argv = argv.slice(0)
+        validateServiceForInvocationStub.restore()
       })
       describe('error handling', () => {
         let implParseInputStub
@@ -849,6 +852,11 @@ scenarios:
           implParseInputStub.throws(new task.def.TaskError('task.error'))
           return slsart.invoke({ d: testJsonScriptStringified })
             .should.be.rejectedWith(task.def.TaskError, 'task.error')
+        })
+        it('handles and reports assets version mismatch errors, exiting the process', () => {
+          validateServiceForInvocationStub.throws(new Error('error'))
+          return slsart.invoke({ d: testJsonScriptStringified })
+            .should.be.rejectedWith(task.def.Error, 'error')
         })
         it('handles and reports unexpected errors, exiting the process', () => {
           implParseInputStub.throws(new Error('error'))


### PR DESCRIPTION
Marks function assets as V0.0.1. Checks local asset version when `invoke` command is used in monitoring mode. If a legacy version is detected (no version number in `package.json`) we display the error message:

```
Your local function project assets in ${cwd()} implements a service
version that does not support invocation with the monitoring flag.

To use monitoring mode, please run the "configure" command
in a clean directory and then customize your worker's assets.
```