### PR TITLE
Updating the version number of NodeJS, Serverless

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ We were motivated to create this project in order to facilitate moving performan
 If you would like a more detailed walk through of motivations, setup, and usage, please consider taking a look at the workshop that was initially presented at the Serverless Conference, London 2016: https://github.com/Nordstrom/serverless-artillery-workshop. Load testing an ApiGateway endpoint?  You may want to use the [artillery-plugin-aws-sigv4](https://github.com/Nordstrom/artillery-plugin-aws-sigv4).  Want to record your results in InfluxDb?  You may want to use [artillery-plugin-influxdb](https://github.com/Nordstrom/artillery-plugin-influxdb).  Want to record your results without setting up a database? You may want to use [artillery-plugin-cloudwatch](https://github.com/Nordstrom/artillery-plugin-cloudwatch).
 
 ## Installation
-We assume you have node.js (v4 or better) installed.  Likewise you should have the serverless framework (v1.0+) either installed globally or available in the local `node_modules`.
+We assume you have node.js (maintenance LTS or higher (v6+)) installed.  Likewise you should have the serverless framework (v1.38+) either installed globally or available in the local `node_modules`.
 
 ```
 npm install -g serverless-artillery


### PR DESCRIPTION
Updating the version number of NodeJS to current maintenance LTS (v6+) and Serverless to v1.38+.

**Issue #:** 
#206

**Cause**
Serverless-artillery requires user to install NodeJS and Serverless before installing serverless-artillery. NodeJS v4 is now deprecated and maintenance LTS is v6 which is our new minimum requirement. With fix for issue #206 we want user to install Serverless v1.38+ in order to reduce number of dependency vulnerability.

**Description of the change**
The change updates the readme to update NodeJS and Serverless version number.

**Questions for reviewer**
None.

**Open issues**
None.

**Tests**
Verified that load testing works with the updated version of NodeJS and serverless.
