### PR TITLE
Using AWS Lambda nodejs10.x runtime.

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ service: serverless-artillery-XnBa473psJ
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs10.x
   iamRoleStatements:
     # This policy allows the function to invoke itself which is important if the script is larger than a single
     # function can produce

--- a/lib/index.js
+++ b/lib/index.js
@@ -318,6 +318,7 @@ scenarios:
    * Copy artillery lambda files to temp dir.
    */
   populateArtilleryLambda: (tempPath) => {
+    console.log(tempPath)
     const sourceArtilleryLambdaPath = path.join(__dirname, 'lambda')
     let anyFailedCopies = false
 
@@ -376,6 +377,13 @@ scenarios:
         if (process.env.DEBUG) console.log(`Missing Artillery Lambda file ${file} in ${targetPath}.`)
         slsFilesMissing = true
       }
+      const fileContents = fs.readFileSync(fullFilePath)
+      const assetFilePath = path.join(__dirname, 'lambda', file)
+      const assetFileContents = fs.readFileSync(assetFilePath)
+      if (!fileContents.equals(assetFileContents)) {
+        if (process.env.DEBUG) console.log(`Artillery Lambda file ${file} differs in ${targetPath}.`)
+        slsFilesMissing = true
+      }
     })
 
     return !slsFilesMissing
@@ -419,7 +427,8 @@ scenarios:
       return userConfig.tempPath
     }
 
-    const tempPath = path.join(os.tmpdir(), 'artillery-lambda')
+    const slug = `${Math.floor(Math.random() * 1000000)}`
+    const tempPath = path.join(os.tmpdir(), `artillery-lambda-${slug}`)
     fs.mkdirSync(tempPath)
 
     // Create new temp dir for Artillery Lambda.

--- a/lib/lambda/serverless.yml
+++ b/lib/lambda/serverless.yml
@@ -14,7 +14,7 @@ service: serverless-artillery
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs10.x
   iamRoleStatements:
     # This policy allows the function to invoke itself which is important if the script is larger than a single
     # function can produce


### PR DESCRIPTION
**Issue #:** 
https://github.com/Nordstrom/serverless-artillery/issues/236

**Cause**
AWS no longer supports the `nodejs8.10`.

**Description of the change**
Updates the `serverless.yml` to target the `nodejs10.x` Lambda runtime.

**Tests**
Tests run including ad-hoc verification that new temp directory is created if asset files differ.