### PR TITLE
Add environment support

### DIFF
--- a/bin/serverless-artillery
+++ b/bin/serverless-artillery
@@ -73,6 +73,11 @@ const yargs = require('yargs')
         description: 'Only write JSON to console.log to facilitate piping the invocation result into a tool such as jq',
         requiresArg: false,
       },
+      e: {
+        alias: 'environment',
+        description: 'Execute the script using the informed environment.',
+        requiresArg: true,
+      },
     },
     /**
      * Custom argument rejection logic, to deal with legacy, argument conflicts (between slsart and sls), and

--- a/lib/index.js
+++ b/lib/index.js
@@ -587,6 +587,10 @@ module.exports = {
         script.mode = modes.MON
       }
 
+      if (options.e || options.environment) {
+        script.environment = options.e || options.environment
+      }
+
       impl.replaceArgv(script)
       // check local assets version
       impl.validateServiceForInvocation(options, script)

--- a/lib/lambda/artillery-task.js
+++ b/lib/lambda/artillery-task.js
@@ -144,7 +144,7 @@ const artilleryTask = {
    * @param script The artillery script to execute in the current function
    * @returns {Promise<*>}
    */
-  execute: (timeNow, script) => new Promise((resolve, reject) => {
+  execute: (timeNow, payload) => new Promise((resolve, reject) => {
     // Since Artillery will call process.exit() upon termination,
     // we monkey-patch it to load result and resolve/reject the Promise.
     const { exit } = process
@@ -164,9 +164,12 @@ const artilleryTask = {
     }
 
     console.log('Starting Artillery...')
-    run(script, { output: (result) => { testResults = result.aggregate } })
+
+    const { environment, ...script } = payload
+
+    run(script, { output: (result) => { testResults = result.aggregate }, environment })
   }).catch((ex) => {
-    const msg = `ERROR exception encountered while executing load from ${script._genesis} in ${timeNow}: ${ex.message}\n${ex.stack}`
+    const msg = `ERROR exception encountered while executing load from ${payload._genesis} in ${timeNow}: ${ex.message}\n${ex.stack}`
     console.error(msg)
     throw new Error(msg)
   }),


### PR DESCRIPTION
**Issue #:** 
https://github.com/Nordstrom/serverless-artillery/issues/293

**Cause**
There is no option to inform the environment that the test is going to be run on

**Description of the change**
Added the `-e` \ `-environment` option to the invoke function and handled it in the lambda so we can pass the environment parameter to Artillery and use the same lambda/script.yaml to target multiple environments

**Tests**
Run multiple load tests with and without the environment invoke arg, and all of them run without any problem
